### PR TITLE
Preventing error wehen message is an object

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -129,7 +129,7 @@
 		}
 
 		function isMessageForUs(){
-			return msgId === '' + msg.substr(0,msgIdLen); //''+Protects against non-string msg
+			return msgId === ('' + msg).substr(0,msgIdLen); //''+Protects against non-string msg
 		}
 
 		function forwardMsgFromIFrame(){


### PR DESCRIPTION
This method throwed "TypeError: Object #<Object> has no method 'substr'" when the message was an object.
