### PR TITLE
Include source files in bower "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "David J. Bradshaw <dave@bradshaw.net>"
   ],
   "description": "Keep same and cross domain iFrames sized to their content with support for window/content resizing, multiple and nested iFrames. (Dependacy free and works with IE8+)",
-  "main": ["js/iframeResizer.min.js", "js/iframeResizer.contentWindow.min.js"],
+  "main": ["src/iframeResizer.js", "src/iframeResizer.contentWindow.js"],
   "keywords": [
     "CrossDomain",
     "Cross-Domain",


### PR DESCRIPTION
Since `iframeResizer.contentWindow.min.js` is a distributable file, it should be part of the bower package.
