### PR TITLE
Allow lowercase <iframe> tags for XHTML complience

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -382,7 +382,7 @@
 
 	function createNativePublicFunction(){
 		function init(element){
-			if('IFRAME' !== element.tagName) {
+			if('IFRAME' !== element.tagName.toUpperCase()) {
 				throw new TypeError('Expected <IFRAME> tag, found <'+element.tagName+'>.');
 			} else {
 				setupIFrame.call(element);


### PR DESCRIPTION
In HTML `element.tagName` is returned in upper-case, but in XHTML it is returned [as it is defined in the document](https://developer.mozilla.org/en-US/docs/Web/API/Element.tagName#Notes).

As XHTML pages are required to have their element names in lower case, as per the [W3C XHTML Spec](http://www.w3.org/TR/xhtml1/#h-4.2), the current code doesn't work in XHTML.

I'm not being pedantic and I don't mean to enforce a style choice either, it's just that browsers do not recognise the tag <IFRAME> when the page is served as XHTML.

Kudos for using the AMD define() though! Thanks!
