### PR TITLE
Listen for transitionend events

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -158,6 +158,7 @@
 		if ( true === autoResize ) {
 			initWindowResizeListener();
 			initWindowClickListener();
+			initTransitionListener();
 			setupMutationObserver();
 		}
 		else {
@@ -241,6 +242,18 @@
 				});
 			}
 		});
+	}
+
+	function initTransitionListener(){
+		function onTransitionEnd(e){
+			if (e.propertyName === 'height' || e.propertyName === 'width') {
+				sendSize('transitionend','Transition end');
+			}
+		}
+		addEventListener(window,'transitionend', onTransitionEnd)
+		addEventListener(window,'webkitTransitionEnd', onTransitionEnd)
+		addEventListener(window,'oTransitionEnd',onTransitionEnd)
+		addEventListener(window,'otransitionend',onTransitionEnd)
 	}
 
 	function setupMutationObserver(){

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -250,10 +250,10 @@
 				sendSize('transitionend','Transition end');
 			}
 		}
-		addEventListener(window,'transitionend', onTransitionEnd)
-		addEventListener(window,'webkitTransitionEnd', onTransitionEnd)
-		addEventListener(window,'oTransitionEnd',onTransitionEnd)
-		addEventListener(window,'otransitionend',onTransitionEnd)
+		addEventListener(window,'transitionend', onTransitionEnd);
+		addEventListener(window,'webkitTransitionEnd', onTransitionEnd);
+		addEventListener(window,'oTransitionEnd',onTransitionEnd);
+		addEventListener(window,'otransitionend',onTransitionEnd);
 	}
 
 	function setupMutationObserver(){


### PR DESCRIPTION
In Safari, I've observed situations along the lines of:

* Changing the DOM class of an element initiates a height transition
* When the attribute change is observed, Safari still reports the body
  height as its pre-transition value
* Once `transitionend` fires, the reported height is correct

I do not observe this behavior on Chrome or Firefox, but the change
herein should not hurt in those browsers either.