### PR TITLE
Add eventCancelTimer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In cases where CSS styles causes the content to flow outside the `body` you may 
 
 <i>Notes:</i>
 
-<i>The **bodyScroll**, **documentElementScroll**, **max** and **min** options can cause screen flicker and will prevent the [interval](#interval) trigger downsizing the iFrame when the content shrinks. This is mainly an issue in IE 10 and below, where the [mutationObserver](https://developer.mozilla.org/en/docs/Web/API/MutationObserver) event is not supported. To overcome this you need to manually trigger a page resize by calling the [parentIFrame.size()](#size-customheight-customwidth) method when you remove content from the page.</i>
+<i>The **bodyScroll**, **documentElementScroll**, **max** and **min** options can cause screen flicker and will prevent the [interval](#interval) trigger downsizing the iFrame when the content shrinks. This is mainly an issue in IE 10 and below, where the [mutationObserver](https://developer.mozilla.org/en/docs/Web/API/MutationObserver) event is not supported. To overcome this you need to manually trigger a page resize by calling the [parentIFrame.size()](#size-customheight-customwidth) method when you remove content from the page. The [eventCancelTimer](#eventCancelTimer) should also be set to a non-zero integer to prevent flicker; `128` milliseconds is recommended.</i>
 
 <i>The **lowestElement** option is the most reliable way of determining the page height. However, it does have a performance impact in older versions of IE. In one screen refresh (16ms) Chrome 34 can calculate the position of around 10,000 html nodes, whereas IE 8 can calculate approximately 50. It is recommend to fallback to **max** or **grow** in IE10 and below.</i>
 
@@ -159,6 +159,14 @@ Resize iFrame to content width.
 	
 Set the number of pixels the iFrame content size has to change by, before triggering resize of the iFrame.
 
+### eventCancelTimer
+
+	default: 0 (in ms)
+	type:    integer
+
+Set the length of time for the trigger to lock before communicating up to the parent page to trigger further resizing. If set to zero, there will be no locking.
+
+For the **bodyScroll**, **documentElementScroll**, **max**, and **min** [heightCalculationMethod](#heightCalculationMethod) options, you should set this to a non-zero number to prevent screen flicker; `128` milliseconds is recommended.
 
 ## Callback Methods
 

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -19,7 +19,7 @@
 		bodyPadding           = '',
 		calculateWidth        = false,
 		doubleEventList       = {'resize':1,'click':1},
-		eventCancelTimer      = 128,
+		eventCancelTimer      = 0,
 		height                = 1,
 		firstRun              = true,
 		heightCalcModeDefault = 'offset',
@@ -102,6 +102,7 @@
 		bodyBackground   = data[9];
 		bodyPadding      = data[10];
 		tolerance        = (undefined !== data[11]) ? Number(data[11]) : tolerance;
+		eventCancelTimer = (undefined !== data[12]) ? Number(data[12]) : eventCancelTimer;
 	}
 
 	function chkCSS(attr,value){
@@ -567,7 +568,7 @@
 			}
 		}
 
-		if (!isDoubleFiredEvent()){
+		if (!isDoubleFiredEvent() || !eventCancelTimer){
 			if (isSizeChangeDetected()){
 				recordTrigger();
 				lockTrigger();

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -568,7 +568,7 @@
 			}
 		}
 
-		if (!isDoubleFiredEvent() || !eventCancelTimer){
+		if (!isDoubleFiredEvent()){
 			if (isSizeChangeDetected()){
 				recordTrigger();
 				lockTrigger();
@@ -582,6 +582,7 @@
 	}
 
 	function lockTrigger(){
+		if (!eventCancelTimer) return;
 		if (!triggerLocked){
 			triggerLocked = true;
 			log('Trigger event lock on');

--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -40,6 +40,7 @@
 			sizeHeight                : true,
 			sizeWidth                 : false,
 			tolerance                 : 0,
+			eventCancelTimer          : 0,
 			closedCallback            : function(){},
 			initCallback              : function(){},
 			messageCallback           : function(){},
@@ -462,7 +463,8 @@
 				':' + settings.heightCalculationMethod +
 				':' + settings.bodyBackground +
 				':' + settings.bodyPadding +
-				':' + settings.tolerance;
+				':' + settings.tolerance +
+				':' + settings.eventCancelTimer;
 		}
 
 		function init(msg){


### PR DESCRIPTION
With simple height calculations, we don't need to worry about the overhead of working out the size of the content on the fly, and thus it is best to not lock the communication between iframes, which allows the height to be immediately updated to reflect the most up-to-date content height.

This sets the default `eventCancelTimer` to zero, which then skips the logic for locking the trigger and allows it to update immediately.

The readme is also updated to reflect this new option and make clear when these settings should be changed from the default.