### PR TITLE
Modified `close` to always trigger change

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -292,7 +292,7 @@
 
 			window.parentIFrame = {
 				close: function closeF(){
-					sendSize('close','parentIFrame.close()', 0, 0);
+					sendSize('close','parentIFrame.close()', Infinity, Infinity);
 				},
 				getId: function getIdF(){
 					return myID;


### PR DESCRIPTION
On line [577](https://github.com/davidjbradshaw/iframe-resizer/blob/master/src/iframeResizer.contentWindow.js#L577) `isSizeChangeDetected()` is called and returns `false` which I believe is the reason the event never propagates to the parent window. I simply modified the `close` event to send `Infinity` rather than 0. 