### PR TITLE
Initialization event race condition fix

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -5,6 +5,7 @@
  * Requires: iframeResizer.js on host page.
  * Author: David J. Bradshaw - dave@bradshaw.net
  * Contributor: Jure Mav - jure.mav@gmail.com
+ * Contributor: Ian Caunce - ian@hallnet.co.uk
  */
 
 ;(function() {

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -685,14 +685,18 @@
 		}
 
 		if (isMessageForUs()){
-			if (firstRun && isInitMsg()){ //Check msg ID
+			if (firstRun === false) {
+				if ('reset' === getMessageType()){
+					resetFromParent();
+				} else if ('resize' === getMessageType()){
+					resizeFromParent();
+				} else if (event.data !== initMsg && !isMiddleTier()){
+					warn('Unexpected message ('+event.data+')');
+				}
+			} else if (isInitMsg()) {
 				initFromParent();
-			} else if ('reset' === getMessageType()){
-				resetFromParent();
-			} else if ('resize' === getMessageType()){
-				resizeFromParent();
-			} else if (event.data !== initMsg && !isMiddleTier()){
-				warn('Unexpected message ('+event.data+')');
+			} else {
+				warn('Received message of type ('+getMessageType()+') before initialization.');
 			}
 		}
 	}


### PR DESCRIPTION
Hi,

I noticed in some browsers, mainly older browsers such as IE9 and <= Android 4.3, the iframe would fail to resize upon page render, especially if the cache had been cleared.
 
There was a race condition whereby a `resize` message would fire before an `init` message was received.

In this race condition, the order of events was as follows:

Host: init
Host: resize
Host: iframe.load

The first init message would fail as the child iframe had not finished rendering. The resize event would then fire causing the width and height to be stored on the closure. The child would respond but the the id would be an empty string as the plugin wasn't initialized. Execution on the host would then fail as `settings[iframeID]` was `undefined` and you attempt to access the `log` attribute on line [352](https://github.com/davidjbradshaw/iframe-resizer/blob/v2.8.6/src/iframeResizer.js#L352).

When the second init event was fired, the plugin would be setup as expected, but because the width & height had already been set by the previous resize message, the child iframe would simply output `No change in size detected`.

This pull request prevents `reset` & `resize` message from triggering a resize event before the plugin has been initialized. If a message is received before initialization, a warning will be outputted to the console.

Thanks, Ian
