### PR TITLE
Add new height method: `lowestVisibleElement`

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -468,6 +468,30 @@
 		return maxBottomVal;
 	}
 
+	function getLowestVisibleElementHeight() {
+		var
+			allElements       = document.querySelectorAll('body *'),
+			allElementsLength = allElements.length,
+			maxBottomVal      = 0,
+			timer             = new Date().getTime();
+
+		for (var i = 0; i < allElementsLength; i++) {
+			var element = allElements[i];
+			if (element.offsetWidth === 0 || element.offsetHeight === 0) continue;
+			var elementBottomVal = element.getBoundingClientRect().bottom
+			if (elementBottomVal > maxBottomVal) {
+				maxBottomVal = elementBottomVal;
+			}
+		}
+
+		timer = new Date().getTime() - timer;
+
+		log('Parsed '+allElementsLength+' HTML elements');
+		log('LowestVisibleElement bottom position calculated in ' + timer + 'ms');
+
+		return maxBottomVal;
+	}
+
 	function getAllHeights(){
 		return [
 			getBodyOffsetHeight(),
@@ -499,7 +523,8 @@
 		max                   : getMaxHeight,
 		min                   : getMinHeight,
 		grow                  : getMaxHeight,
-		lowestElement         : getBestHeight
+		lowestElement         : getBestHeight,
+		lowestVisibleElement  : getLowestVisibleElementHeight
 	};
 
 	function getWidth(){


### PR DESCRIPTION
This adds a `heightCalculationMethod` for only checking the heights of elements that are visible on the page (`display: block` vs. `display: none`) to ensure that we're not checking for hidden elements when resizing the frame.

As with jQuery, "Elements with `visibility: hidden` or `opacity: 0` are considered visible, since they still consume space in the layout."