### PR TITLE
Allow loading without window object

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -9,7 +9,7 @@
  * Contributor: Ian Caunce - ian@hallnet.co.uk
  */
 
-;(function() {
+;(function(window) {
 	'use strict';
 
 	var
@@ -718,4 +718,4 @@
 
 	addEventListener(window, 'message', receiver);
 
-})();
+})(window || {});

--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -7,7 +7,7 @@
  * Contributor: Jure Mav - jure.mav@gmail.com
  * Contributor: Reed Dadoune - reed@dadoune.com
  */
-;(function() {
+;(function(window) {
 	'use strict';
 
 	var
@@ -648,4 +648,4 @@
 		window.iFrameResize = window.iFrameResize || factory();
 	}
 
-})();
+})(window || {});


### PR DESCRIPTION
Allows files to be loaded in node.js, eg. when running tests in projects that depend on iframe-resizer.