### PR TITLE
Updated checkOrigin setting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Override the default body margin style in the iFrame. A string can be any valid 
 	default: true
 	type:    boolean || array
 
-When set to true, only allow incoming messages from the domain listed in the `src` property of the iFrame tag. If your iFrame navigates between different domains, ports or protocols; then you will need to provide an array of domains or disable this option.
+When set to true, only allow incoming messages from the domain listed in the `src` property of the iFrame tag. If your iFrame navigates between different domains, ports or protocols; then you will need to provide an array of URLs or disable this option.
 
 ### inPageLinks
 


### PR DESCRIPTION
If custom URLs are used they must be specified by URL - not by domain