### PR TITLE
support re-applying iframe-resizer if iframe was destroyed in the meantime

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -602,7 +602,7 @@
 		}
 
 		function beenHere(){
-			return (iframeId in settings);
+			return (iframeId in settings && 'iFrameResizer' in iframe);
 		}
 
 		var iframeId = ensureHasId(iframe.id);


### PR DESCRIPTION
Hello,

Thanks for this very useful tool !

The problem fixed by this PR occurs when iframes are created/destroyed then re-created dynamically. Iframe-resizer keeps a cache of applied settings that does not match reality.