### PR TITLE
Issue #244 iframe not resizing correctly when images are included in …

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -450,11 +450,10 @@
 	function setupMutationObserver(){
 		function addImageLoadListners(mutation) {
 			function addImageLoadListener(element){
-				var imageLoaded = sendSize.bind(null,'imageLoad','Image loaded',undefined,undefined);
-
-				if (isNotSet(element.height) || isNotSet(element.width)) {
-					log('Attach listerner to ' + element.src);
+				if (element.complete === false) {
+					log('Attach listener to ' + element.src);
 					element.addEventListener('load', imageLoaded, false);
+					element.addEventListener('error', imageLoaded, false);
 				}
 			}
 
@@ -468,11 +467,17 @@
 			}
 		}
 
+		function imageLoaded(event) {
+			event.target.removeEventListener('load', imageLoaded, false);
+			event.target.removeEventListener('error', imageLoaded, false);
+			sendSize('imageLoad','Image loaded: ' + event.target.src, undefined, undefined);
+		}
+
 		function mutationObserved(mutations) {
 			sendSize('mutationObserver','mutationObserver: ' + mutations[0].target + ' ' + mutations[0].type);
 
 			//Deal with WebKit asyncing image loading when tags are injected into the page
-			addImageLoadListners(mutations[0]);
+			mutations.forEach(addImageLoadListners);
 		}
 
 		function createMutationObserver(){

--- a/test/lateImageLoad.html
+++ b/test/lateImageLoad.html
@@ -50,6 +50,30 @@
           }
         });
       });
+      
+      asyncTest( "iFrame late image load with other mutations", function() {
+
+        var callbackCounter = 0;
+
+        $('iframe').iFrameResize({
+          log:true,
+          sizeHeight:false,
+          sizeWidth:true,
+          interval:1,
+          resizedCallback:function(messageData){
+            switch  (''+(++callbackCounter)){
+              case '1':
+                sendMessage('imageAsSecondMutation');
+                break;
+              case '2':
+                break;
+              case '3':
+                ok( 'imageLoad' === messageData.type, 'type = imageLoad');
+                start();
+            }
+          }
+        });
+      });    
     }
 
     if (MutationObserver)

--- a/test/resources/frame.content.html
+++ b/test/resources/frame.content.html
@@ -13,6 +13,8 @@
 
 		<b>iFrame</b> 
 
+		<div>Some content to be replaced</div>
+		
 		<p>
 			Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 		</p>
@@ -157,6 +159,10 @@
 							case 'image':
 								$('p').html('<img src="djb.jpg">');
 								break;
+							case 'imageAsSecondMutation':
+								$('div').html('How now brown cow');
+								$('p').html('<img src="djb.jpg">');
+								break;								
 						}
 
 					}


### PR DESCRIPTION
Added back support for checking each mutation for images.  Replaced event listener optimization check on image height/width with check on image.complete flag as height/width seem to be set in IE and Firefox with erroneous values even if not set on the actual image tag. Replaced bind approach for
registering image load event listener with event listener function to avoid registering multiple listeners for same image and also so the listener can be removed.  Also added listener for error event so that images which fail to load are handled cleanly.