### PR TITLE
Fix for margin issue

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -668,7 +668,7 @@
 		}
 
 		var retVal = 0;
-		el = typeof el !== 'undefined' ? el : document.body;
+		el =  el || document.body;
 
 		/* istanbul ignore else */ // Not testable in phantonJS
 		if (('defaultView' in document) && ('getComputedStyle' in document.defaultView)) {

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -645,7 +645,7 @@
 
 	// document.documentElement.offsetHeight is not reliable, so
 	// we have to jump through hoops to get a better value.
-	function getComputedBodyStyle(prop,el) {
+	function getComputedStyle(prop,el) {
 		/* istanbul ignore next */  //Not testable in PhantomJS
 		function convertUnitsToPxForIE8(value) {
 			var PIXEL = /^\d+(px)?$/i;
@@ -698,7 +698,7 @@
 			timer          = getNow();
 
 		for (var i = 0; i < elementsLength; i++) {
-			elVal = elements[i].getBoundingClientRect()[side] + getComputedBodyStyle('margin'+Side,elements[i]);
+			elVal = elements[i].getBoundingClientRect()[side] + getComputedStyle('margin'+Side,elements[i]);
 			if (elVal > maxVal) {
 				maxVal = elVal;
 			}
@@ -741,7 +741,7 @@
 	var
 		getHeight = {
 			bodyOffset: function getBodyOffsetHeight(){
-				return  document.body.offsetHeight + getComputedBodyStyle('marginTop') + getComputedBodyStyle('marginBottom');
+				return  document.body.offsetHeight + getComputedStyle('marginTop') + getComputedStyle('marginBottom');
 			},
 
 			offset: function(){

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -667,9 +667,8 @@
 			return value;
 		}
 
-		var
-			el = typeof el !== 'undefined' ? el : document.body,
-			retVal = 0;
+		var retVal = 0;
+		el = typeof el !== 'undefined' ? el : document.body;
 
 		/* istanbul ignore else */ // Not testable in phantonJS
 		if (('defaultView' in document) && ('getComputedStyle' in document.defaultView)) {

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -645,7 +645,7 @@
 
 	// document.documentElement.offsetHeight is not reliable, so
 	// we have to jump through hoops to get a better value.
-	function getComputedBodyStyle(prop) {
+	function getComputedBodyStyle(prop,el) {
 		/* istanbul ignore next */  //Not testable in PhantomJS
 		function convertUnitsToPxForIE8(value) {
 			var PIXEL = /^\d+(px)?$/i;
@@ -668,7 +668,7 @@
 		}
 
 		var
-			el = document.body,
+			el = typeof el !== 'undefined' ? el : document.body,
 			retVal = 0;
 
 		/* istanbul ignore else */ // Not testable in phantonJS
@@ -699,7 +699,7 @@
 			timer          = getNow();
 
 		for (var i = 0; i < elementsLength; i++) {
-			elVal = elements[i].getBoundingClientRect()[side] + getComputedBodyStyle('margin'+Side);
+			elVal = elements[i].getBoundingClientRect()[side] + getComputedBodyStyle('margin'+Side,elements[i]);
 			if (elVal > maxVal) {
 				maxVal = elVal;
 			}


### PR DESCRIPTION
Hi,

This is hopefully a fix for the margin issue here: davidjbradshaw/iframe-resizer#281

Two simple changes are made. getComputedBodyStyle takes an extra parameter to specify the element to check. If nothing is passed, it will fall back to the previous behaviour of using the body element. Additionally, when getMaxElement iterates over its list of elements, the element is passed to getComputedBodyStyle in order to fetch that elements margin.
