### PR TITLE
support server side rendering

### DIFF
--- a/js/iframeResizer.contentWindow.js
+++ b/js/iframeResizer.contentWindow.js
@@ -12,6 +12,8 @@
 
 ;(function(window, undefined) {
 	'use strict';
+	
+	if(!window) return;
 
 	var
 		autoResize            = true,
@@ -1101,4 +1103,4 @@
 
 	
 
-})(window || {});
+})(typeof window !== 'undefined' && window);

--- a/js/iframeResizer.js
+++ b/js/iframeResizer.js
@@ -12,6 +12,8 @@
 ;(function(window) {
 	'use strict';
 
+	if(!window) return;
+	
 	var
 		count                 = 0,
 		logEnabled            = false,
@@ -1013,4 +1015,4 @@
 		window.iFrameResize = window.iFrameResize || factory();
 	}
 
-})(window || {});
+})(typeof window !== 'undefined' && window);


### PR DESCRIPTION
When using in server side rendering scenarios (i.e using React) this package once required will throw an exception because the `window` object is not defined.

This fix prevents both host and guest scripts from doing anything if the `window` object is not defined, preserving the same behavior when used client side.