### PR TITLE
fix jquery reference

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -1022,7 +1022,7 @@
 		}
 	}
 
-	if (window.jQuery) { createJQueryPublicMethod(jQuery); }
+	if (window.jQuery) { createJQueryPublicMethod(window.jQuery); }
 
 	if (typeof define === 'function' && define.amd) {
 		define([],factory);


### PR DESCRIPTION
I'm not 100% sure what's going on, hopefully you understand better than I do.

The changes in 3.5.10 broke our app, with an error "jQuery is not defined"  on this line. Adding `window.` fixes the issue.
