### PR TITLE
Run "resizedCallback" *after* the resize actually happened (closes #455)

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -138,6 +138,7 @@
 			function resize(){
 				setSize(messageData);
 				setPagePosition(iframeId);
+				callback('resizedCallback',messageData);
 			}
 
 			ensureInRange('Height');
@@ -460,11 +461,9 @@
 			case 'init':
 				resizeIFrame();
 				callback('initCallback',messageData.iframe);
-				callback('resizedCallback',messageData);
 				break;
 			default:
 				resizeIFrame();
-				callback('resizedCallback',messageData);
 			}
 		}
 


### PR DESCRIPTION
Moved callback as discussed in issue #455.
Couldn't run tests because `grunt` binary not found after `npm install`.