### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ if ('parentIFrame' in window) {
 
 
 
-##IFrame Object Methods
+## IFrame Object Methods
 
 Once the iFrame has been initialized, an `iFrameResizer` object is bound to it. This has the following methods available.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
