### PR TITLE
Add CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This library enables the automatic resizing of the height and width of both same
 
 ### Install
 
-This package can be installed via NPM (`npm install iframe-resizer -save`), Yarn (`yarn add iframe-resizer`) or Bower (`bower install iframe-resizer`).
+This package can be installed via NPM (`npm install iframe-resizer -save`), Yarn (`yarn add iframe-resizer`), Bower (`bower install iframe-resizer`) or [jsDelivr](https://www.jsdelivr.com/package/npm/iframe-resizer).
 
 ### Getting started
 The package contains two minified JavaScript files in the [js](js) folder. The first ([iframeResizer.min.js](https://raw.githubusercontent.com/davidjbradshaw/iframe-resizer/master/js/iframeResizer.min.js)) is for the page hosting the iFrames. It can be called with **native** JavaScript;


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/iframe-resizer) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.