### PR TITLE
Fix throttling of init event #554

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -928,7 +928,11 @@
 
 		if (!isDoubleFiredEvent()){
 			recordTrigger();
-			sizeIFrameThrottled(triggerEvent, triggerEventDesc, customHeight, customWidth);
+			if (triggerEvent in {'init':1}){
+				sizeIFrame(triggerEvent, triggerEventDesc, customHeight, customWidth);
+			} else {
+				sizeIFrameThrottled(triggerEvent, triggerEventDesc, customHeight, customWidth);
+			}
 		} else {
 			log('Trigger event cancelled: '+triggerEvent);
 		}


### PR DESCRIPTION
When firing `init` event from the content window, call original (unthrottled) `sizeIFrame()` as opposed to calling throttled one.