### PR TITLE
Passive Event Listener for Performance

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -66,20 +66,32 @@
         return document.body.scrollWidth;
       }
     },
-    eventHandlersByName   = {};
+    eventHandlersByName   = {},
+    passiveSupported = false,
+    onceSupported = false;
 
+  function noop() {}
 
-  function addEventListener(el,evt,func) {
-    /* istanbul ignore else */ // Not testable in phantonJS
+  try {
+    var options = Object.create({}, {
+      passive: {get: function() { passiveSupported = true }},
+      once: {get: function() { onceSupported = true }},
+    })
+    window.addEventListener('test', noop, options)
+    window.removeEventListener('test', noop, options)
+  } catch (e) { /* */ }
+
+  function addEventListener(el,evt,func,options) {
+    /* istanbul ignore else */ // Not testable in phantomJS
     if ('addEventListener' in window) {
-      el.addEventListener(evt,func, false);
+      el.addEventListener(evt,func, passiveSupported ? (options||{}) : false);
     } else if ('attachEvent' in window) { //IE
       el.attachEvent('on'+evt,func);
     }
   }
 
   function removeEventListener(el,evt,func) {
-    /* istanbul ignore else */ // Not testable in phantonJS
+    /* istanbul ignore else */ // Not testable in phantomJS
     if ('removeEventListener' in window) {
       el.removeEventListener(evt,func, false);
     } else if ('detachEvent' in window) { //IE
@@ -277,7 +289,7 @@
 
         eventHandlersByName[eventName] = handleEvent;
 
-        addEventListener(window,eventName,handleEvent);
+        addEventListener(window,eventName,handleEvent,{passive:true});
       },
       remove: function(eventName) {
         var handleEvent = eventHandlersByName[eventName];


### PR DESCRIPTION
Events such as touchstart and scroll must be registered in modern browsers with passive event listeners.

#595 