### PR TITLE
Add extra check for middle tier on jquery

### DIFF
--- a/js/iframeResizer.contentWindow.js
+++ b/js/iframeResizer.contentWindow.js
@@ -1060,7 +1060,8 @@
     }
 
     function isMiddleTier() {
-      return !(typeof module !== 'undefined' && module.exports) && ('iFrameResize' in window);
+      return !(typeof module !== 'undefined' && module.exports) && ('iFrameResize' in window) ||
+        ('jQuery' in window) && ('iFrameResize' in window.jQuery.prototype);
     }
 
     function isInitMsg() {


### PR DESCRIPTION
Check if the iFrameResize function is attached to the prototype of jQuery to see if contentWindow is on an intermediary tier