### PR TITLE
Update to add alternative method to do post iframe close cleanup

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -545,14 +545,18 @@
     return retVal;
   }
 
+  function removeIframeListeners(iframe) {
+    var iframeId = iframe.id;
+    delete settings[iframeId];
+  }
+
   function closeIFrame(iframe) {
     var iframeId = iframe.id;
-
     log(iframeId,'Removing iFrame: '+iframeId);
     if (iframe.parentNode) { iframe.parentNode.removeChild(iframe); }
     chkCallback(iframeId,'closedCallback',iframeId);
     log(iframeId,'--');
-    delete settings[iframeId];
+    removeIframeListeners(iframe);
   }
 
   function getPagePosition(iframeId) {
@@ -784,6 +788,8 @@
         settings[iframeId].iframe.iFrameResizer = {
 
           close        : closeIFrame.bind(null,settings[iframeId].iframe),
+
+          removeListeners: removeIframeListeners.bind(null,settings[iframeId].iframe),
 
           resize       : trigger.bind(null,'Window resize', 'resize', settings[iframeId].iframe),
 


### PR DESCRIPTION
Fixes https://github.com/davidjbradshaw/iframe-resizer/issues/601 and https://github.com/davidjbradshaw/iframe-resizer/issues/576 which is ultimately to "iframe not found" warnings when a component which implements has unmounted in React.

@davidjbradshaw I noticed that you attempted to fix this with a `try catch`, however the existing `close()` command causes a side effect in React (and possibly other frame works that manage the DOM tree and/or virtual DOMs) that the `try catch` won't prevent.

By exposing an alternative method, we can use it to prevent the warnings when used in React (such as https://github.com/zeroasterisk/react-iframe-resizer-super)