### PR TITLE
adds .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+.DS_Store
+.coveralls.yml
+.idea
+node_modules
+bin
+example
+test
+spec
+npm-debug.log
+bower_components
+coverage*

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ bin
 example
 test
 spec
+src
 npm-debug.log
 bower_components
 coverage*


### PR DESCRIPTION
The archive generated by npm can be checked with command:
```bash
npm pack
```
For more reference, visit this [page](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package)

Intended to fix https://github.com/davidjbradshaw/iframe-resizer/issues/656