### PR TITLE
Check for iframe.src when parsing it for remoteHost

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -1096,10 +1096,12 @@
       settings[iframeId] = {
         firstRun: true,
         iframe: iframe,
-        remoteHost: iframe.src
-          .split('/')
-          .slice(0, 3)
-          .join('/')
+        remoteHost:
+          iframe.src &&
+          iframe.src
+            .split('/')
+            .slice(0, 3)
+            .join('/')
       }
 
       checkOptions(options)


### PR DESCRIPTION
It seems that some blockers and extensions like to maniuplate/delete the `src` attribute from `iframes`. Also it might be that you create an iframe without an `src` (e.g. using `srcDoc`).

I was experiencing an annoying bug https://github.com/davidjbradshaw/iframe-resizer/issues/721, this fixed it for me.