### PR TITLE
Fix issue 772; Use existing iframe DOM element instead of document.ge…

### DIFF
--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -576,7 +576,7 @@
         trigger(
           'iFrame requested init',
           createOutgoingMsg(iframeId),
-          document.getElementById(iframeId),
+          settings[iframeId].iframe,
           iframeId
         )
       }
@@ -1275,7 +1275,7 @@
 
     Object.keys(settings).forEach(function(iframeId) {
       if (isIFrameResizeEnabled(iframeId)) {
-        trigger(eventName, event, document.getElementById(iframeId), iframeId)
+        trigger(eventName, event, settings[iframeId].iframe, iframeId)
       }
     })
   }


### PR DESCRIPTION
I'm not able to test with your automated tests.
I tried with jasmine and with qunit.

qunit in Chrome work, but shadowRoot not seems to be supported with PhantomJS.
with jasmine, even with the master code, the tests passed.