### PR TITLE
Replace const with var

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,4 @@
-const iframeResize = require('./iframeResizer')
+var iframeResize = require('./iframeResizer')
 
 exports.iframeResize = iframeResize
 exports.iframeResizer = iframeResize // Backwards compatability


### PR DESCRIPTION
The main file is currently using the `const` keyword. Assuming we want to use this script in IE 10 or are using an [outdated UglifyJS](https://stackoverflow.com/questions/47439067/uglifyjs-throws-unexpected-token-keyword-const-with-node-modules), we would have to make sure we transpile the import due to this single expression.

Related: https://github.com/davidjbradshaw/iframe-resizer/issues/760