### PR TITLE
docs: add Ember addon to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ IFrame-Resizer provides an extensive range of options and APIs for both the pare
   - [React](https://github.com/davidjbradshaw/iframe-resizer-react)
   - [Vue](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/use_with/vue.md)
   - [Angular](https://github.com/davidjbradshaw/iframe-resizer/issues/478#issuecomment-347958630)
+  - [Ember](https://github.com/alexlafroscia/ember-iframe-resizer-modifier)
   - [jQuery](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/use_with/jquery.md)
 - [Troubleshooting](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/troubleshooting.md)
 - [Upgrade from version 3](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/upgrade.md)


### PR DESCRIPTION
I put together an Ember addon today as an idiomatic example of how to integrate `iframe-resizer` with Ember.js. I figured it would be a good thing to mention in this project's `README` along with the other framework integration examples!