### PR TITLE
Renamed `dimention` to `dimensions`

### DIFF
--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -894,12 +894,12 @@
     return maxVal
   }
 
-  function getAllMeasurements(dimention) {
+  function getAllMeasurements(dimensions) {
     return [
-      dimention.bodyOffset(),
-      dimention.bodyScroll(),
-      dimention.documentElementOffset(),
-      dimention.documentElementScroll()
+      dimensions.bodyOffset(),
+      dimensions.bodyScroll(),
+      dimensions.documentElementOffset(),
+      dimensions.documentElementScroll()
     ]
   }
 


### PR DESCRIPTION
Looks like there was a spelling mistake, I've simply renamed `dimention` to `dimensions`