### PR TITLE
Correct import statement and typos in Vue example

### DIFF
--- a/docs/use_with/vue.md
+++ b/docs/use_with/vue.md
@@ -2,17 +2,18 @@
 
 Create the following Vue directive
 
-```
+```js
 import Vue from 'vue'
-import {iframeResize} from 'iframe-resizer';
+import iframeResize from 'iframe-resizer/js/iframeResizer';
 
 Vue.directive('resize', {
   bind: function(el, { value = {} }) {
-    el.addEventListener('load', () => iFrameResize(value, el))
+    el.addEventListener('load', () => iframeResize(value, el))
   }
 })
 ```
-and then include it on you page as follows.
+
+and then include it on your page as follows.
 
 ```html
 <iframe


### PR DESCRIPTION
The example may work as written, but the directive would be relying on a global `window.iFrameResize` function, not the one imported, `iframeResize`. If the global function isn't present or is shadowed by another script, the directive will fail or call the wrong function.

Furthermore, importing at the package root will include the contents of both `js/iframeResize.js` and `js/iframeResizer.contentWindow.js`. Module bundlers like webpack can't tree-shake the files because of side effects.  Better to just import the default export of `js/iframeResizer.js` if that's all we're going to use.