### PR TITLE
Remove listeners when unbinding in Vue

### DIFF
--- a/docs/use_with/vue.md
+++ b/docs/use_with/vue.md
@@ -9,6 +9,9 @@ import iframeResize from 'iframe-resizer/js/iframeResizer';
 Vue.directive('resize', {
   bind: function(el, { value = {} }) {
     el.addEventListener('load', () => iframeResize(value, el))
+  },
+  unbind: function (el) {
+    el.iFrameResizer.removeListeners();
   }
 })
 ```


### PR DESCRIPTION
Add unbind method to the Vue's directive example, to remove the iFrameResizer's listeners when the directive is unbound from the element.