### PR TITLE
Fix doc typo and readme broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This package can be installed via NPM (`npm install iframe-resizer --save`).
 
 ### Usage
 
-The package contains two minified JavaScript files in the [js](https://github.com/davidjbradshaw/iframe-resizer/js) folder. The first ([iframeResizer.min.js](https://raw.githubusercontent.com/davidjbradshaw/iframe-resizer/master/js/iframeResizer.min.js)) is for the page hosting the iFrames. It can be called with via JavaScript:
+The package contains two minified JavaScript files in the [js](https://github.com/davidjbradshaw/iframe-resizer/tree/master/js) folder. The first ([iframeResizer.min.js](https://raw.githubusercontent.com/davidjbradshaw/iframe-resizer/master/js/iframeResizer.min.js)) is for the page hosting the iFrames. It can be called with via JavaScript:
 
 ```js
 const iframes = iFrameResize( [{options}], [css selector] || [iframe] );

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -116,4 +116,4 @@ By default only changes in height are detected, if you want to calculate the wid
 
 ### Frame has not responded within 5 seconds
 
-This can happen when postMessage is being blocked in browser. There could be multiple reasons to that but in some cases we found that RocketLoader extension within Cloudflare is was the reason. Try disabling it if you are using cloudflare.
+This can happen when postMessage is being blocked in browser. There could be multiple reasons to that but in some cases we found that RocketLoader extension within Cloudflare was the reason. Try disabling it if you are using cloudflare.


### PR DESCRIPTION
Fix broken link at README, getting started [usage section](https://github.com/davidjbradshaw/iframe-resizer#usage):
Old (broken js folder link):
The package contains two minified JavaScript files in the [js](https://github.com/davidjbradshaw/iframe-resizer/js) folder...
New (working js folder link):
The package contains two minified JavaScript files in the [js](https://github.com/davidjbradshaw/iframe-resizer/tree/master/js) folder...

Fix typo at [Troubleshooting page](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/troubleshooting.md):
Remove 'is' before 'was`.
Old:
This can happen when postMessage is being blocked in browser. There could be multiple reasons to that but in some cases we found that RocketLoader extension within Cloudflare **is was** the reason. Try disabling it if you are using cloudflare.
New:
This can happen when postMessage is being blocked in browser. There could be multiple reasons to that but in some cases we found that RocketLoader extension within Cloudflare **was** the reason. Try disabling it if you are using cloudflare.