### PR TITLE
Fix various typos

### DIFF
--- a/docs/iframed_page/options.md
+++ b/docs/iframed_page/options.md
@@ -16,7 +16,7 @@ The following options can be set from within the iFrame page by creating a `wind
 	default: '*'
 	type: string
 
-This option allows you to restrict the domain of the parent page, to prevent other sites mimicing your parent page.
+This option allows you to restrict the domain of the parent page, to prevent other sites mimicking your parent page.
 
 ### heightCalculationMethod / widthCalculationMethod
 

--- a/docs/parent_page/options.md
+++ b/docs/parent_page/options.md
@@ -70,7 +70,7 @@ In cases where CSS styles causes the content to flow outside the `body` you may 
 * **documentElementScroll** uses `document.documentElement.scrollHeight` <sup>*</sup>
 * **max** takes the largest value of the main four options <sup>*</sup>
 * **min** takes the smallest value of the main four options <sup>*</sup>
-* **lowestElement** Loops though every element in the the DOM and finds the lowest bottom point <sup>†</sup>
+* **lowestElement** Loops though every element in the DOM and finds the lowest bottom point <sup>†</sup>
 * **taggedElement** Finds the bottom of the lowest element with a `data-iframe-height` attribute
 
 <i>Notes:</i>
@@ -152,7 +152,7 @@ Some CSS techniques may require you to change this setting to one of the followi
 * **scroll** takes the largest value of the two scroll options <sup>*</sup>
 * **max** takes the largest value of the main four options <sup>*</sup>
 * **min** takes the smallest value of the main four options <sup>*</sup>
-* **rightMostElement** Loops though every element in the the DOM and finds the right most point <sup>†</sup>
+* **rightMostElement** Loops though every element in the DOM and finds the right most point <sup>†</sup>
 * **taggedElement** Finds the left most element with a `data-iframe-width` attribute
 
 Alternatively it is possible to add your own custom sizing method directly inside the iFrame, see the [iFrame Page Options](../iframed_page/options.md) section for more details

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,9 +2,9 @@
 
 The first steps to investigate a problem is to make sure you are using the latest version and then enable the [log](#log) option, which outputs everything that happens to the [JavaScript Console](https://developers.google.com/chrome-developer-tools/docs/console#opening_the_console). This will enable you to see what both the iFrame and host page are up to and also see any JavaScript error messages.
 
-Solutions for the most common problems are outlined in this section. If you need futher help, then please ask questions on [StackOverflow](http://stackoverflow.com/questions/tagged/iframe-resizer) with the `iframe-resizer` tag.
+Solutions for the most common problems are outlined in this section. If you need further help, then please ask questions on [StackOverflow](http://stackoverflow.com/questions/tagged/iframe-resizer) with the `iframe-resizer` tag.
 
-Bug reports and pull requests are welcome on the [issue tracker](https://github.com/davidjbradshaw/iframe-resizer/issues). Please read the [contributing guidelines](https://github.com/davidjbradshaw/iframe-resizer/blob/master/CONTRIBUTING.md) before openning a ticket, as this will ensure a faster resolution.
+Bug reports and pull requests are welcome on the [issue tracker](https://github.com/davidjbradshaw/iframe-resizer/issues). Please read the [contributing guidelines](https://github.com/davidjbradshaw/iframe-resizer/blob/master/CONTRIBUTING.md) before opening a ticket, as this will ensure a faster resolution.
 
 ### Multiple IFrames on one page
 
@@ -112,7 +112,7 @@ By default the origin of incoming messages is checked against the `src` attribut
 
 ### Width not resizing
 
-By default only changes in height are detected, if you want to calculate the width you need to set the `sizeWidth` opion to true and the `sizeHeight` option to false.
+By default only changes in height are detected, if you want to calculate the width you need to set the `sizeWidth` option to true and the `sizeHeight` option to false.
 
 ### Frame has not responded within 5 seconds
 

--- a/example/frame.absolute.html
+++ b/example/frame.absolute.html
@@ -64,7 +64,7 @@
       prevents the normal height calculation, which is based on the body tag
       from returning the correct height. To work around this you can set the
       <b>heightCalculationMethod</b> option to use one of the other page height
-      propeties.
+      properties.
     </p>
     <p>
       Use the dropdown to change the sizing method of the page, select the
@@ -90,7 +90,7 @@
     <p>
       <i
         >This option should be used sparingly, as the alternate methods can be
-        less acurate at working out the correct page size, can cause screen
+        less accurate at working out the correct page size, can cause screen
         flicker and can sometimes fail to reduce in size when the frame content
         changes in browsers that do not support mutationObservers (See
         <a href="http://caniuse.com/mutationobserver">caniuse.com</a> for

--- a/example/frame.tolerance.html
+++ b/example/frame.tolerance.html
@@ -48,12 +48,12 @@
       >
     </p>
     <p>
-      This page has an absolute position elemnt that take it out side the normal
+      This page has an absolute position element that take it out side the normal
       document body, which is marked with a red border on this page. This
       prevents the normal height calculation, which is based on the body tag
       from returning the correct height. To work around this you can set the
       <b>heightCalculationMethod</b> option to use one of the other page height
-      propeties.
+      properties.
     </p>
     <p>
       Use the dropdown to change the sizing method of the page, select the
@@ -78,7 +78,7 @@
     <p>
       <i
         >This option should be used sparingly, as the alternate methods can be
-        less acurate at working out the correct page size, can cause screen
+        less accurate at working out the correct page size, can cause screen
         flicker and can sometimes fail to reduce in size when the frame content
         changes in browsers that do not support mutationObservers (See
         <a href="http://caniuse.com/mutationobserver">caniuse.com</a> for

--- a/js/iframeResizer.contentWindow.js
+++ b/js/iframeResizer.contentWindow.js
@@ -945,7 +945,7 @@
       },
 
       offset: function () {
-        return getHeight.bodyOffset() // Backwards compatability
+        return getHeight.bodyOffset() // Backwards compatibility
       },
 
       bodyScroll: function getBodyScrollHeight() {
@@ -1213,7 +1213,7 @@
       },
       inPageLink: function inPageLinkF() {
         this.moveToAnchor()
-      }, // Backward compatability
+      }, // Backward compatibility
 
       pageInfo: function pageInfoFromParent() {
         var msgBody = getData()
@@ -1254,7 +1254,7 @@
 
     function isInitMsg() {
       // Test if this message is from a child below us. This is an ugly test, however, updating
-      // the message format would break backwards compatibity.
+      // the message format would break backwards compatibility.
       return event.data.split(':')[2] in { true: 1, false: 1 }
     }
 

--- a/js/iframeResizer.js
+++ b/js/iframeResizer.js
@@ -1317,11 +1317,11 @@
   /* istanbul ignore next */
   function tabVisible() {
     function resize() {
-      sendTriggerMsg('Tab Visable', 'resize')
+      sendTriggerMsg('Tab Visible', 'resize')
     }
 
     if ('hidden' !== document.visibilityState) {
-      log('document', 'Trigger event: Visiblity change')
+      log('document', 'Trigger event: Visibility change')
       debouce(resize, 16)
     }
   }

--- a/js/iframeResizer.js
+++ b/js/iframeResizer.js
@@ -276,7 +276,7 @@
 
     function isMessageFromMetaParent() {
       // Test if this message is from a parent above us. This is an ugly test, however, updating
-      // the message format would break backwards compatibity.
+      // the message format would break backwards compatibility.
       var retCode = messageData.type in { true: 1, false: 1, undefined: 1 }
 
       if (retCode) {

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,5 @@
 var iframeResize = require('./iframeResizer')
 
 exports.iframeResize = iframeResize
-exports.iframeResizer = iframeResize // Backwards compatability
+exports.iframeResizer = iframeResize // Backwards compatibility
 exports.iframeResizerContentWindow = require('./iframeResizer.contentWindow')

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -945,7 +945,7 @@
       },
 
       offset: function () {
-        return getHeight.bodyOffset() // Backwards compatability
+        return getHeight.bodyOffset() // Backwards compatibility
       },
 
       bodyScroll: function getBodyScrollHeight() {
@@ -1213,7 +1213,7 @@
       },
       inPageLink: function inPageLinkF() {
         this.moveToAnchor()
-      }, // Backward compatability
+      }, // Backward compatibility
 
       pageInfo: function pageInfoFromParent() {
         var msgBody = getData()
@@ -1254,7 +1254,7 @@
 
     function isInitMsg() {
       // Test if this message is from a child below us. This is an ugly test, however, updating
-      // the message format would break backwards compatibity.
+      // the message format would break backwards compatibility.
       return event.data.split(':')[2] in { true: 1, false: 1 }
     }
 

--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -1317,11 +1317,11 @@
   /* istanbul ignore next */
   function tabVisible() {
     function resize() {
-      sendTriggerMsg('Tab Visable', 'resize')
+      sendTriggerMsg('Tab Visible', 'resize')
     }
 
     if ('hidden' !== document.visibilityState) {
-      log('document', 'Trigger event: Visiblity change')
+      log('document', 'Trigger event: Visibility change')
       debouce(resize, 16)
     }
   }

--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -276,7 +276,7 @@
 
     function isMessageFromMetaParent() {
       // Test if this message is from a parent above us. This is an ugly test, however, updating
-      // the message format would break backwards compatibity.
+      // the message format would break backwards compatibility.
       var retCode = messageData.type in { true: 1, false: 1, undefined: 1 }
 
       if (retCode) {

--- a/test/interval.html
+++ b/test/interval.html
@@ -26,7 +26,7 @@
       'use strict'
       var msgId = '[iFrameSizerTest]:'
 
-      asyncTest('iFrame negative inteval timer ', function() {
+      asyncTest('iFrame negative interval timer ', function() {
         var evtCounter = 0,
           started = false
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.min.js,CHANGELOG.md -L afterall,ba,depricate,eacf,ot,trough,vew`