### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/spec/lib/common.js
+++ b/spec/lib/common.js
@@ -63,5 +63,5 @@ function closeChild(window, done) {
 }
 
 function strEnd(str, num) {
-  return str.substr(str.length - num);
+  return str.slice(-num);
 }

--- a/src/iframeResizer.contentWindow.js
+++ b/src/iframeResizer.contentWindow.js
@@ -195,7 +195,7 @@
       return 'true' === str
     }
 
-    var data = initMsg.substr(msgIdLen).split(':')
+    var data = initMsg.slice(msgIdLen).split(':')
 
     myID = data[0]
     bodyMargin = undefined !== data[1] ? Number(data[1]) : bodyMargin // For V1 compatibility
@@ -1233,7 +1233,7 @@
     }
 
     function isMessageForUs() {
-      return msgID === ('' + event.data).substr(0, msgIdLen) // ''+ Protects against non-string messages
+      return msgID === ('' + event.data).slice(0, msgIdLen) // ''+ Protects against non-string messages
     }
 
     function getMessageType() {
@@ -1241,7 +1241,7 @@
     }
 
     function getData() {
-      return event.data.substr(event.data.indexOf(':') + 1)
+      return event.data.slice(event.data.indexOf(':') + 1)
     }
 
     function isMiddleTier() {

--- a/src/iframeResizer.js
+++ b/src/iframeResizer.js
@@ -160,7 +160,7 @@
     }
 
     function processMsg() {
-      var data = msg.substr(msgIdLen).split(':')
+      var data = msg.slice(msgIdLen).split(':')
       var height = data[1] ? parseInt(data[1], 10) : 0
       var iframe = settings[data[0]] && settings[data[0]].iframe
       var compStyle = getComputedStyle(iframe)
@@ -269,8 +269,8 @@
 
     function isMessageForUs() {
       return (
-        msgId === ('' + msg).substr(0, msgIdLen) &&
-        msg.substr(msgIdLen).split(':')[0] in settings
+        msgId === ('' + msg).slice(0, msgIdLen) &&
+        msg.slice(msgIdLen).split(':')[0] in settings
       ) // ''+Protects against non-string msg
     }
 
@@ -287,7 +287,7 @@
     }
 
     function getMsgBody(offset) {
-      return msg.substr(msg.indexOf(':') + msgHeaderLen + offset)
+      return msg.slice(msg.indexOf(':') + msgHeaderLen + offset)
     }
 
     function forwardMsgFromIFrame(msgBody) {

--- a/test/v1.html
+++ b/test/v1.html
@@ -102,7 +102,7 @@
             }
 
             function processMsg() {
-              var data = msg.substr(msgIdLen).split(':')
+              var data = msg.slice(msgIdLen).split(':')
 
               messageData = {
                 iframe: document.getElementById(data[0]),
@@ -114,7 +114,7 @@
             var messageData = {}
 
             //check message is for us.
-            if (msgId === msg.substr(0, msgIdLen)) {
+            if (msgId === msg.slice(0, msgIdLen)) {
               processMsg()
               resize()
               settings.callback(messageData, settings)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.