### PR TITLE
fix: react types

### DIFF
--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -1,57 +1,52 @@
-declare module "iframe-resizer-react" {
-  import * as React from "react";
+import * as React from 'react'
 
-  namespace IframeResizer {
-    type IFrameObject = {
-      close: () => void;
-      moveToAnchor: (anchor: string) => void;
-      resize: () => void;
-      sendMessage: (message: any, targetOrigin?: string) => void;
-      removeListeners: () => void;
-    };
-    interface IFrameComponent extends HTMLIFrameElement {
-      iFrameResizer: IFrameObject;
-    }
-
-    type IframeProps = React.DetailedHTMLProps<
-      React.IframeHTMLAttributes<HTMLIFrameElement>,
-      HTMLIFrameElement
-    >;
-
-    type ResizerOptions = {
-      bodyBackground?: string | null;
-      bodyMargin?: string | number | null;
-      bodyPadding?: string | number | null;
-      checkOrigin?: boolean | string[];
-      direction?: "vertical" | "horizontal" | "none";
-      forwardRef?: any;
-      inPageLinks?: boolean;
-      enablePublicMethods?: boolean;
-      offsetHeight?: number;
-      offsetWidth?: number;
-      scrolling?: boolean | "omit";
-      tolerance?: number;
-    };
-
-    type ResizerEvents = {
-      onInit?: (iframe: IFrameComponent) => void;
-      onMessage?: (ev: { iframe: IFrameComponent; message: any }) => void;
-      onResized?: (ev: {
-        iframe: IFrameComponent;
-        height: number;
-        width: number;
-        type: string;
-      }) => void;
-      onScroll?: (ev: { x: number; y: number }) => boolean;
-    };
-
-    type IframeResizerProps = Omit<IframeProps, "scrolling"> &
-      ResizerOptions &
-      ResizerEvents;
-  }
-
-  function IframeResizer(
-    props: IframeResizer.IframeResizerProps
-  ): React.ReactElement;
-  export = IframeResizer;
+export type IFrameObject = {
+  close: () => void
+  moveToAnchor: (anchor: string) => void
+  resize: () => void
+  sendMessage: (message: any, targetOrigin?: string) => void
+  removeListeners: () => void
 }
+export interface IFrameComponent extends HTMLIFrameElement {
+  iFrameResizer: IFrameObject
+}
+
+export type IframeProps = React.DetailedHTMLProps<
+  React.IframeHTMLAttributes<HTMLIFrameElement>,
+  HTMLIFrameElement
+>
+
+export type ResizerOptions = {
+  bodyBackground?: string | null
+  bodyMargin?: string | number | null
+  bodyPadding?: string | number | null
+  checkOrigin?: boolean | string[]
+  direction?: 'vertical' | 'horizontal' | 'none'
+  forwardRef?: any
+  inPageLinks?: boolean
+  enablePublicMethods?: boolean
+  offsetHeight?: number
+  offsetWidth?: number
+  scrolling?: boolean | 'omit'
+  tolerance?: number
+}
+
+export type ResizerEvents = {
+  onInit?: (iframe: IFrameComponent) => void
+  onMessage?: (ev: { iframe: IFrameComponent; message: any }) => void
+  onResized?: (ev: {
+    iframe: IFrameComponent
+    height: number
+    width: number
+    type: string
+  }) => void
+  onScroll?: (ev: { x: number; y: number }) => boolean
+}
+
+export type IframeResizerProps = Omit<IframeProps, 'scrolling'> &
+  ResizerOptions &
+  ResizerEvents
+
+export default function IframeResizer(
+  props: IframeResizerProps,
+): React.ReactElement


### PR DESCRIPTION
See https://github.com/davidjbradshaw/iframe-resizer/issues/1228#issuecomment-2066238569

I removed all module and namespace declarations, and the errors went away.

Please note that this is a major breaking change, as types are now imported rather than appended as a property to the default export.  The types change also assumes that the react package is `esm`.