### PR TITLE
Fix typos in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 Iframe Resizer Version 5
 
-This JavaScript library is Copyright © 2013-2024 David J. Bradshaw, and is distobuted for non-comercial usage under the GPL V3. Comerercial license available upon request.
+This JavaScript library is Copyright © 2013-2024 David J. Bradshaw and is distributed under the GPL V3 for non-commercial use. A commercial license is available upon request.
 
-For more infomation on comercial licensing contact dave@bradshaw.net
+For more information on commercial licensing contact dave@bradshaw.net
 
 --
 


### PR DESCRIPTION
Fix typos in LICENSE introduced in #1212: 
- `distobuted` -> distributed, 
- `comercial` -> commercial
- `infomation` -> information