### PR TITLE
Added: Alias getParentProps -> getParentProperties

### DIFF
--- a/example/child/frame.animate.html
+++ b/example/child/frame.animate.html
@@ -82,7 +82,7 @@
       This iframe contains a page element animated via CSS to change the height of the page. 
     </p>
 
-    <h4>Data returned by parentIFrame.getParentProperties()</h4>
+    <h4>Data returned by parentIFrame.getParentProps()</h4>
     <table id="data"></table>
 
     <!-- 
@@ -130,7 +130,7 @@
           //   parentIFrame.getPageInfo((pageInfo) => {
           //     dataTable.innerHTML = Object.entries(pageInfo).map(row).join('\n')
           //   })
-          parentIFrame.getParentProperties((pageInfo) => {
+          parentIFrame.getParentProps((pageInfo) => {
             dataTable.innerHTML = Object.entries(pageInfo).map(rowParent).join('\n')
           })
         },

--- a/example/react/child/frame.animate.html
+++ b/example/react/child/frame.animate.html
@@ -82,7 +82,7 @@
       This iframe contains a page element animated via CSS to change the height of the page. 
     </p>
 
-    <h4>Data returned by parentIFrame.getParentProperties()</h4>
+    <h4>Data returned by parentIFrame.getParentProps()</h4>
     <table id="data"></table>
 
     <!-- 
@@ -130,7 +130,7 @@
           //   parentIFrame.getPageInfo((pageInfo) => {
           //     dataTable.innerHTML = Object.entries(pageInfo).map(row).join('\n')
           //   })
-          window.parentIFrame.getParentProperties((pageInfo) => {
+          window.parentIframe.getParentProps((pageInfo) => {
             dataTable.innerHTML = Object.entries(pageInfo).map(rowParent).join('\n')
           })
         },

--- a/packages/child/index.d.ts
+++ b/packages/child/index.d.ts
@@ -53,7 +53,7 @@ declare module '@iframe-resizer/child' {
        *
        * Pass false to disable the callback.
        */
-      getParentProperties(callback: (data: ParentProperties) => void): void
+      getParentProps(callback: (data: ParentProperties) => void): void
 
       /**
        * Scroll the parent page to the coordinates x and y

--- a/packages/child/index.d.ts
+++ b/packages/child/index.d.ts
@@ -53,7 +53,7 @@ declare module '@iframe-resizer/child' {
        *
        * Pass false to disable the callback.
        */
-      getParentProps(callback: (data: ParentProperties) => void): void
+      getParentProps(callback: (data: ParentProps) => void): void
 
       /**
        * Scroll the parent page to the coordinates x and y
@@ -84,7 +84,7 @@ declare module '@iframe-resizer/child' {
       size(customHeight?: string, customWidth?: string): void
     }
 
-    interface ParentProperties {
+    interface ParentProps {
       /**
        * The values returned by iframe.getBoundingClientRect()
        */

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -657,7 +657,7 @@ The <b>getPageInfo()</> method has been deprecated and replaced with  <b>getPare
       advise(
         `<rb>Renamed Method</>
           
-The <b>getParentProperties()</> method has been renamed <b>getParentProps()</>. Use of this method will be removed in a future version of <i>iframe-resizer</>.
+The <b>getParentProperties()</> method has been renamed <b>getParentProps()</>. Use of the old name will be removed in a future version of <i>iframe-resizer</>.
 `,
       )
       this.getParentProps(callback)

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -627,7 +627,7 @@ function setupPublicMethods() {
         advise(
           `<rb>Deprecated Method</>
           
-The <b>getPageInfo()</> method has been deprecated and replaced with  <b>getParentProperties()</>. Use of this method will be removed in a future version of <i>iframe-resizer</>.
+The <b>getPageInfo()</> method has been deprecated and replaced with  <b>getParentProps()</>. Use of this method will be removed in a future version of <i>iframe-resizer</>.
 `,
         )
         return
@@ -637,10 +637,10 @@ The <b>getPageInfo()</> method has been deprecated and replaced with  <b>getPare
       sendMsg(0, 0, 'pageInfoStop')
     },
 
-    getParentProperties(callback) {
+    getParentProps(callback) {
       if (typeof callback !== 'function') {
         throw new TypeError(
-          'parentIFrame.getParentProperties(callback) callback not a function',
+          'parentIFrame.getParentProps(callback) callback not a function',
         )
       }
 
@@ -651,6 +651,16 @@ The <b>getPageInfo()</> method has been deprecated and replaced with  <b>getPare
         onParentInfo = null
         sendMsg(0, 0, 'parentInfoStop')
       }
+    },
+
+    getParentProperties(callback) {
+      advise(
+        `<rb>Renamed Method</>
+          
+The <b>getParentProperties()</> method has been renamed <b>getParentProps()</>. Use of this method will be removed in a future version of <i>iframe-resizer</>.
+`,
+      )
+      this.getParentProps(callback)
     },
 
     moveToAnchor(hash) {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -180,7 +180,7 @@ function iframeListener(event) {
     })
   }
 
-  function getParentProperties() {
+  function getParentProps() {
     const { iframe } = messageData
     const { scrollWidth, scrollHeight } = document.documentElement
     const { width, height, offsetLeft, offsetTop, pageLeft, pageTop, scale } =
@@ -282,10 +282,7 @@ function iframeListener(event) {
   }
 
   const sendPageInfoToIframe = sendInfoToIframe('pageInfo', getPageInfo)
-  const sendParentInfoToIframe = sendInfoToIframe(
-    'parentInfo',
-    getParentProperties,
-  )
+  const sendParentInfoToIframe = sendInfoToIframe('parentInfo', getParentProps)
 
   const startPageInfoMonitor = startInfoMonitor(
     sendPageInfoToIframe,


### PR DESCRIPTION
Rename getParentProperties to getParentProps and create an alias of the old name to the new with dep warning.