### PR TITLE
Added: waitForLoad option

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -971,7 +971,8 @@ The \u001B[removeListeners()</> method has been renamed to \u001B[disconnect()</
 
     if (settings[iframeId].mode >= 0) {
       addEventListener(iframe, 'load', iFrameLoaded)
-      trigger('init', `${msg}:${setup}`, id, true)
+      if (settings[iframeId].waitForLoad === false)
+        trigger('init', `${msg}:${setup}`, id, true)
     }
   }
 

--- a/packages/core/values/defaults.js
+++ b/packages/core/values/defaults.js
@@ -37,6 +37,7 @@ export default Object.freeze({
   sizeWidth: false,
   warningTimeout: 5000,
   tolerance: 0,
+  waitForLoad: false,
   widthCalculationMethod: 'auto',
   onClose: () => true,
   onClosed() {},

--- a/packages/parent/index.d.ts
+++ b/packages/parent/index.d.ts
@@ -89,6 +89,8 @@ declare module '@iframe-resizer/parent' {
        */
       tolerance?: number | undefined
 
+      waitForLoad?: boolean | undefined
+
       warningTimeout?: number | undefined
 
       /**

--- a/packages/vue/iframe-resizer.vue
+++ b/packages/vue/iframe-resizer.vue
@@ -55,6 +55,7 @@
             .entries(this.$props)
             .filter(([key, value]) => value !== undefined)
         ),
+        waitForLoad: true,
 
         onClose: () => false, // Disable close methods, use Vue to remove iframe
         onReady: (...args) => self.$emit('onReady', ...args),
@@ -64,9 +65,7 @@
 
       const connectWithOptions = connectResizer(options)
 
-      iframe.addEventListener("load", () => {
-        self.resizer = connectWithOptions(iframe)
-      })
+      self.resizer = connectWithOptions(iframe)
     },
     
     beforeUnmount() {


### PR DESCRIPTION
Add `waitForLoad` option.

By default _iframe-resizer_ tries to send a message to the iframe as soon as it has been called. This creates problems for frameworks like Vue as they will always manage to make this call before the iframe has had time to load.

Setting this option to true stops an erroneous error message in the browser console from being displayed.