### PR TITLE
Added: Only check overflowed elements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "delog",
     "filesize",
     "iife",
+    "Initialising",
     "logcapture",
     "Loggable",
     "sarif",

--- a/example/child/frame.animate.html
+++ b/example/child/frame.animate.html
@@ -99,11 +99,11 @@
 
     <script>
       // Add some content to to show the effect of using data-iframe-size above
-      for (let i = 0; i < 10_000; i++) {
-        document.write(
-          '<div style="position: absolute">This is a test to see if the page will grow to accommodate the content.</div>',
-  );
-      }
+  //     for (let i = 0; i < 10_000; i++) {
+  //       document.write(
+  //         '<div style="position: absolute">This is a test to see if the page will grow to accommodate the content.</div>',
+  // );
+  //     }
       
     </script>
 

--- a/example/child/frame.animate.html
+++ b/example/child/frame.animate.html
@@ -99,11 +99,11 @@
 
     <script>
       // Add some content to to show the effect of using data-iframe-size above
-  //     for (let i = 0; i < 10_000; i++) {
-  //       document.write(
-  //         '<div style="position: absolute">This is a test to see if the page will grow to accommodate the content.</div>',
-  // );
-  //     }
+      for (let i = 0; i < 10_000; i++) {
+        document.body.appendChild(
+          '<div style="position: absolute">This is a test to see if the page will grow to accommodate the content.</div>',
+  );
+      }
       
     </script>
 

--- a/example/child/frame.animate.html
+++ b/example/child/frame.animate.html
@@ -85,6 +85,8 @@
     <h4>Data returned by parentIFrame.getParentProps()</h4>
     <table id="data"></table>
 
+    <span id="insert"></span>
+
     <!-- 
       The data-iframe-size attribute tells iframe-resizer to use this element
       to calculate the height of the iframe, when the content overflows the
@@ -101,6 +103,7 @@
       // Add some content to to show the effect of using data-iframe-size above
       for (let i = 0; i < 500; i++) {
         const span = document.createElement('span')
+        span.style.setProperty('position', 'relative')
         span.textContent = `. `
         document.getElementById('insert').append(span);
       }

--- a/example/child/frame.animate.html
+++ b/example/child/frame.animate.html
@@ -99,10 +99,10 @@
 
     <script>
       // Add some content to to show the effect of using data-iframe-size above
-      for (let i = 0; i < 10_000; i++) {
-        document.body.appendChild(
-          '<div style="position: absolute">This is a test to see if the page will grow to accommodate the content.</div>',
-  );
+      for (let i = 0; i < 500; i++) {
+        const span = document.createElement('span')
+        span.textContent = `. `
+        document.getElementById('insert').append(span);
       }
       
     </script>

--- a/example/child/frame.content.html
+++ b/example/child/frame.content.html
@@ -8,7 +8,6 @@
     <script
       type="text/javascript"
       src="../../js/iframe-resizer.child.js"
-      defer
     ></script>
     <script>
       function toggle() {

--- a/example/html/width.html
+++ b/example/html/width.html
@@ -22,7 +22,7 @@
     <h2>Automagically resizing iFrame</h2>
     <p>
       Back to
-      <a name="anchorParentTest" href="index.html">horizontal iFrames</a>.
+      <a name="anchorParentTest" href="index.html">vertical iframes</a>.
     </p>
     <div id="iframeContainer" style="margin: 20px">
       <iframe

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -171,7 +171,6 @@ function init() {
   checkHeightMode()
   checkWidthMode()
   checkDeprecatedAttrs()
-  checkHasDataSizeAttributes()
 
   setupObserveOverflow()
   setupCalcElements()
@@ -453,23 +452,6 @@ function checkDeprecatedAttrs() {
           
 The <b>data-iframe-height</> and <b>data-iframe-width</> attributes have been deprecated and replaced with the single <b>data-iframe-size</> attribute. Use of the old attributes will be removed in a future version of <i>iframe-resizer</>.`,
     )
-  }
-}
-
-function checkHasDataSizeAttributes() {
-  if (document.querySelectorAll(`[${SIZE_ATTR}]`).length > 0) {
-    if (heightCalcMode === 'auto') {
-      heightCalcMode = 'autoOverflow'
-      log(
-        'data-iframe-size attribute found on page, using "autoOverflow" calculation method for height',
-      )
-    }
-    if (widthCalcMode === 'auto') {
-      widthCalcMode = 'autoOverflow'
-      log(
-        'data-iframe-size attribute found on page, using "autoOverflow" calculation method for width',
-      )
-    }
   }
 }
 
@@ -1077,9 +1059,7 @@ const getBodyOffset = () => {
 const getHeight = {
   enabled: () => calculateHeight,
   getOffset: () => offsetHeight,
-  type: 'height',
   auto: () => getAutoSize(getHeight),
-  autoOverflow: () => getAutoSize(getHeight),
   bodyOffset: getBodyOffset,
   bodyScroll: () => document.body.scrollHeight,
   offset: () => getHeight.bodyOffset(), // Backwards compatibility
@@ -1098,9 +1078,7 @@ const getHeight = {
 const getWidth = {
   enabled: () => calculateWidth,
   getOffset: () => offsetWidth,
-  type: 'width',
   auto: () => getAutoSize(getWidth),
-  autoOverflow: () => getAutoSize(getWidth),
   bodyScroll: () => document.body.scrollWidth,
   bodyOffset: () => document.body.offsetWidth,
   custom: () => customCalcMethods.width(),

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -873,11 +873,11 @@ function setupMutationObserver() {
   bodyObserver = setupBodyMutationObserver()
 }
 
-function usedEl(el) {
+function usedEl(el, Side) {
   if (usedTags.has(el)) return true
   addUsedTag(el)
   info(
-    `\nHeight calculated from: ${getElementName(el)} (${elementSnippet(el)})`,
+    `\n${Side} position calculated from: ${getElementName(el)} (${elementSnippet(el)})`,
   )
   return false
 }
@@ -922,7 +922,7 @@ function getMaxElement(side) {
 
   timer = performance.now() - timer
 
-  if (len > 1) usedEl(maxEl)
+  if (len > 1) usedEl(maxEl, Side)
 
   const logMsg = `
 Parsed ${len} element${len === SINGLE ? '' : 's'} in ${timer.toPrecision(3)}ms

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -784,9 +784,13 @@ const checkPositionType = (element) => {
 const getAllNonStaticElements = () =>
   [...getAllElements(document)()].filter(checkPositionType)
 
+const resizeSet = new WeakSet()
+
 function setupResizeObservers(el) {
   if (!el) return
+  if (resizeSet.has(el)) return
   resizeObserver.observe(el)
+  resizeSet.add(el)
   log(`Attached resizeObserver: ${getElementName(el)}`)
 }
 

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -191,7 +191,7 @@ function init() {
 }
 
 // Continue init after intersection observer has been setup
-const initContinue = once(() => {
+const initContinue = () => {
   sendSize('init', 'Init message from host page', undefined, undefined, VERSION)
   sendTitle()
   initEventListeners()
@@ -199,12 +199,12 @@ const initContinue = once(() => {
   isInit = false
   log('Initialization complete')
   log('---')
-})
+}
 
 function setupObserveOverflow() {
   if (calculateHeight === calculateWidth) return
   observeOverflow = overflowObserver({
-    init: initContinue,
+    onChange: once(initContinue),
     side: calculateHeight ? 'bottom' : 'right',
   })
 }

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -979,42 +979,6 @@ const getAllElements = (element) => () =>
     '* :not(head):not(body):not(meta):not(base):not(title):not(script):not(link):not(style):not(map):not(area):not(option):not(optgroup):not(template):not(track):not(wbr):not(nobr)',
   )
 
-// const switchChecked = false
-
-// function switchToAutoOverflow({ getDimension, isHeight }) {
-//   if (!switchChecked) {
-//     // If this just happens once, then it is likely we just came from a large page.
-//     switchChecked = true
-//     return getDimension.taggedElement()
-//   }
-
-//   // const furthest = isHeight ? 'lowest' : 'right most'
-//   // const side = isHeight ? 'bottom' : 'right'
-//   //   const overflowDetectedMessage = `<rb>Detected content overflowing html element</>
-
-//   // This causes <i>iframe-resizer</> to fall back to checking the position of every element on the page in order to calculate the correct dimensions of the iframe. Inspecting the size, ${side} margin, and position of every visible HTML element will have a performance impact on more complex pages.
-
-//   // To fix this issue, and remove this warning, you can either ensure the content of the page does not overflow the <b><HTML></> element or alternatively you can add the attribute <b>data-iframe-size</> to the elements on the page that you want <i>iframe-resizer</> to use when calculating the dimensions of the iframe.
-
-//   // When present the ${side} margin of the ${furthest} element with a <b>data-iframe-size</> attribute will be used to set the ${dimension} of the iframe.
-
-//   // More info: https://iframe-resizer.com/performance.
-
-//   // (Page size: ${scrollSize} > document size: ${ceilBoundingSize})`
-
-//   //   advise(overflowDetectedMessage)
-
-//   if (isHeight) {
-//     log(`Switching from ${heightCalcMode} to autoOverflow`)
-//     heightCalcMode = 'autoOverflow'
-//   } else {
-//     log(`Switching from ${widthCalcMode} to autoOverflow`)
-//     widthCalcMode = 'autoOverflow'
-//   }
-
-//   return getDimension.taggedElement()
-// }
-
 const prevScrollSize = {
   height: 0,
   width: 0,
@@ -1035,7 +999,7 @@ function getAutoSize(getDimension) {
     return boundingSize
   }
 
-  const isOverflowed = isOverflowed()
+  const hasOverflow = isOverflowed()
   const isHeight = getDimension === getHeight
   const dimension = isHeight ? 'height' : 'width'
   const boundingSize = getDimension.documentElementBoundingClientRect()
@@ -1051,14 +1015,11 @@ function getAutoSize(getDimension) {
     case hasTags:
       return getDimension.taggedElement()
 
-    case !isOverflowed &&
+    case !hasOverflow &&
       prevBoundingSize[dimension] === 0 &&
       prevScrollSize[dimension] === 0:
       log(`Initial page size values: ${sizes}`)
-      if (getDimension.taggedElement(true) <= ceilBoundingSize) {
-        return returnBoundingClientRect()
-      }
-      break
+      return returnBoundingClientRect()
 
     case triggerLocked &&
       boundingSize === prevBoundingSize[dimension] &&
@@ -1070,28 +1031,20 @@ function getAutoSize(getDimension) {
       log(`Page is hidden: ${sizes}`)
       return scrollSize
 
-    case !isOverflowed &&
+    case !hasOverflow &&
       boundingSize !== prevBoundingSize[dimension] &&
       scrollSize <= prevScrollSize[dimension]:
       log(
         `New HTML bounding size: ${sizes}`,
         'Previous bounding size:',
         prevBoundingSize[dimension],
-        'Bounding size:',
-        boundingSize,
       )
       return returnBoundingClientRect()
 
     case !isHeight:
       return getDimension.taggedElement()
-    // return autoOverflow
-    //   ? getDimension.taggedElement()
-    //   : switchToAutoOverflow({
-    //       getDimension,
-    //       isHeight,
-    //     })
 
-    case !isOverflowed && boundingSize < prevBoundingSize[dimension]:
+    case !hasOverflow && boundingSize < prevBoundingSize[dimension]:
       log('HTML bounding size decreased:', sizes)
       return returnBoundingClientRect()
 
@@ -1102,13 +1055,6 @@ function getAutoSize(getDimension) {
     case boundingSize > scrollSize:
       log(`Page size < HTML bounding size: ${sizes}`)
       return returnBoundingClientRect()
-
-    // case !autoOverflow:
-    //   log(`Switch to autoOverflow: ${sizes}`)
-    //   return switchToAutoOverflow({
-    //     getDimension,
-    //     isHeight,
-    //   })
 
     default:
       log(`Content overflowing HTML element: ${sizes}`)

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -2,7 +2,7 @@ import { BASE, SINGLE, SIZE_ATTR, VERSION } from '../common/consts'
 import formatAdvise from '../common/format-advise'
 import { addEventListener, removeEventListener } from '../common/listeners'
 import { getModeData } from '../common/mode'
-import { once } from '../common/utils'
+import { id, once } from '../common/utils'
 import {
   getOverflowedElements,
   isOverflowed,
@@ -80,7 +80,7 @@ let mouseEvents = false
 let myID = ''
 let offsetHeight
 let offsetWidth
-let observeOverflow = (x) => x
+let observeOverflow = id
 let resizeFrom = 'child'
 let resizeObserver = null
 let sameDomain = false

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -191,31 +191,31 @@ function init() {
 }
 
 // Continue init after intersection observer has been setup
-const start = once(() => {
+const initContinue = once(() => {
   sendSize('init', 'Init message from host page', undefined, undefined, VERSION)
   sendTitle()
-  startEventListeners()
+  initEventListeners()
   onReady()
   isInit = false
   log('Initialization complete')
   log('---')
 })
 
+function setupObserveOverflow() {
+  if (calculateHeight === calculateWidth) return
+  observeOverflow = overflowObserver({
+    init: initContinue,
+    side: calculateHeight ? 'bottom' : 'right',
+  })
+}
+
 function setupCalcElements() {
   const taggedElements = document.querySelectorAll(`[${SIZE_ATTR}]`)
   hasTags = taggedElements.length > 0
   log(`Tagged elements found: ${hasTags}`)
   calcElements = hasTags ? taggedElements : getAllElements(document)()
-  if (hasTags) setTimeout(start)
+  if (hasTags) setTimeout(initContinue)
   else observeOverflow(calcElements)
-}
-
-function setupObserveOverflow() {
-  if (calculateHeight === calculateWidth) return
-  observeOverflow = overflowObserver({
-    start,
-    side: calculateHeight ? 'bottom' : 'right',
-  })
 }
 
 function sendTitle() {
@@ -499,7 +499,7 @@ function checkMode() {
   return mode
 }
 
-function startEventListeners() {
+function initEventListeners() {
   if (autoResize !== true) {
     log('Auto Resize disabled')
     return
@@ -648,7 +648,7 @@ function setupPublicMethods() {
     autoResize: (resize) => {
       if (resize === true && autoResize === false) {
         autoResize = true
-        startEventListeners()
+        initEventListeners()
       } else if (resize === false && autoResize === true) {
         autoResize = false
         stopEventListeners()

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -5,7 +5,7 @@ import { getModeData } from '../common/mode'
 import {
   getOverflowedElements,
   isOverflowed,
-  observeOverflow,
+  overflowObserver,
 } from './overflow'
 
 const PERF_TIME_LIMIT = 4
@@ -79,6 +79,7 @@ let mouseEvents = false
 let myID = ''
 let offsetHeight
 let offsetWidth
+let observeOverflow = () => null
 let resizeFrom = 'child'
 let resizeObserver = null
 let sameDomain = false
@@ -177,6 +178,7 @@ function init() {
   setupCalcElements()
   setupPublicMethods()
   setupMouseEvents()
+  setupObserveOverflow()
   startEventListeners()
   inPageLinks = setupInPageLinks()
   addUsedTag(document.documentElement)
@@ -185,6 +187,13 @@ function init() {
   sendTitle()
   onReady()
   isInit = false
+}
+
+function setupObserveOverflow() {
+  if (calculateHeight === calculateWidth) return
+  observeOverflow = overflowObserver({
+    side: calculateHeight ? 'bottom' : 'right',
+  })
 }
 
 function sendTitle() {
@@ -409,7 +418,7 @@ function checkDeprecatedAttrs() {
     document.querySelectorAll(`[${attr}]`).forEach((el) => {
       found = true
       el.removeAttribute(attr)
-      el.setAttribute(SIZE_ATTR, null)
+      el.setAttribute(SIZE_ATTR, true)
     })
 
   checkAttrs('data-iframe-height')

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -79,7 +79,7 @@ let mouseEvents = false
 let myID = ''
 let offsetHeight
 let offsetWidth
-let observeOverflow = () => null
+let observeOverflow = (x) => x
 let resizeFrom = 'child'
 let resizeObserver = null
 let sameDomain = false

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -958,7 +958,7 @@ const getAllMeasurements = (dimension) => [
 
 const getAllElements = (element) => () =>
   element.querySelectorAll(
-    '* :not(head):not(body):not(meta):not(base):not(title):not(script):not(link):not(style):not(map):not(area):not(option):not(optgroup):not(template):not(track):not(wbr):not(nobr)',
+    '* :not(head):not(meta):not(base):not(title):not(script):not(link):not(style):not(map):not(area):not(option):not(optgroup):not(template):not(track):not(wbr):not(nobr)',
   )
 
 const prevScrollSize = {

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -886,16 +886,8 @@ function getMaxElement(side) {
     : document.documentElement.getBoundingClientRect().bottom
   let timer = performance.now()
 
-  const elements = [] // TODO: remove
-
   const targetElements =
     !hasTags && isOverflowed() ? getOverflowedElements() : calcElements
-
-  // console.log('!hasTags', !hasTags)
-  console.log('isOverflowed', isOverflowed())
-  console.log('test', !hasTags && isOverflowed())
-  console.log('targetElements', targetElements)
-  // console.log('calcElements', calcElements)
 
   let len = targetElements.length
 
@@ -908,9 +900,6 @@ function getMaxElement(side) {
       len -= 1
       return
     }
-
-    // console.log('element', element)
-    elements.push(element) // TODO: remove
 
     elVal =
       element.getBoundingClientRect()[side] +
@@ -932,7 +921,7 @@ ${Side} ${hasTags ? 'tagged ' : ''}element found at: ${maxVal}px
 Position calculated from HTML element: ${getElementName(maxEl)} (${elementSnippet(maxEl, 100)})`
 
   if (timer < PERF_TIME_LIMIT || len < PERF_MIN_ELEMENTS || hasTags || isInit) {
-    console.log(logMsg, elements) // log(logMsg)
+    log(logMsg)
   } else if (perfWarned < timer && perfWarned < lastTimer) {
     perfWarned = timer * 1.2
     advise(

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -1,4 +1,11 @@
-import { BASE, SINGLE, SIZE_ATTR, VERSION } from '../common/consts'
+import {
+  BASE,
+  HEIGHT_EDGE,
+  SINGLE,
+  SIZE_ATTR,
+  VERSION,
+  WIDTH_EDGE,
+} from '../common/consts'
 import formatAdvise from '../common/format-advise'
 import { addEventListener, removeEventListener } from '../common/listeners'
 import { getModeData } from '../common/mode'
@@ -205,7 +212,7 @@ function setupObserveOverflow() {
   if (calculateHeight === calculateWidth) return
   observeOverflow = overflowObserver({
     onChange: once(initContinue),
-    side: calculateHeight ? 'bottom' : 'right',
+    side: calculateHeight ? HEIGHT_EDGE : WIDTH_EDGE,
   })
 }
 
@@ -1071,8 +1078,8 @@ const getHeight = {
   max: () => Math.max(...getAllMeasurements(getHeight)),
   min: () => Math.min(...getAllMeasurements(getHeight)),
   grow: () => getHeight.max(),
-  lowestElement: () => getMaxElement('bottom'),
-  taggedElement: () => getMaxElement('bottom'),
+  lowestElement: () => getMaxElement(HEIGHT_EDGE),
+  taggedElement: () => getMaxElement(HEIGHT_EDGE),
 }
 
 const getWidth = {
@@ -1088,10 +1095,10 @@ const getWidth = {
     document.documentElement.getBoundingClientRect().right,
   max: () => Math.max(...getAllMeasurements(getWidth)),
   min: () => Math.min(...getAllMeasurements(getWidth)),
-  rightMostElement: () => getMaxElement('right'),
+  rightMostElement: () => getMaxElement(WIDTH_EDGE),
   scroll: () =>
     Math.max(getWidth.bodyScroll(), getWidth.documentElementScroll()),
-  taggedElement: () => getMaxElement('right'),
+  taggedElement: () => getMaxElement(WIDTH_EDGE),
 }
 
 function sizeIFrame(

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -2,7 +2,11 @@ import { BASE, SINGLE, SIZE_ATTR, VERSION } from '../common/consts'
 import formatAdvise from '../common/format-advise'
 import { addEventListener, removeEventListener } from '../common/listeners'
 import { getModeData } from '../common/mode'
-import { isOverflowed, observeOverflow } from './overflow'
+import {
+  getOverflowedElements,
+  isOverflowed,
+  observeOverflow,
+} from './overflow'
 
 const PERF_TIME_LIMIT = 4
 const PERF_MIN_ELEMENTS = 99
@@ -876,37 +880,37 @@ function getMaxElement(side) {
   const Side = capitalizeFirstLetter(side)
 
   let elVal = 0
-  let len = calcElements.length
   let maxEl = document.documentElement
   let maxVal = hasTags
     ? 0
     : document.documentElement.getBoundingClientRect().bottom
   let timer = performance.now()
 
-  const elements = []
+  const elements = [] // TODO: remove
 
-  calcElements.forEach((element) => {
+  const targetElements =
+    !hasTags && isOverflowed() ? getOverflowedElements() : calcElements
+
+  // console.log('!hasTags', !hasTags)
+  console.log('isOverflowed', isOverflowed())
+  console.log('test', !hasTags && isOverflowed())
+  console.log('targetElements', targetElements)
+  // console.log('calcElements', calcElements)
+
+  let len = targetElements.length
+
+  targetElements.forEach((element) => {
     if (
       !hasTags &&
-      hasCheckVisibility &&
+      hasCheckVisibility && // Safari missing checkVisibility
       !element.checkVisibility(checkVisibilityOptions)
     ) {
-      console.log(`Skipping non-visible element: ${getElementName(element)}`)
       len -= 1
       return
     }
 
-    if (!hasTags && !isOverflowed(element)) {
-      // console.log(
-      //   `Skipping contained element: ${getElementName(element)}`,
-      //   element,
-      // )
-      len -= 1
-      return
-    }
-    elements.push(element)
-
-    console.log(isOverflowed(element))
+    // console.log('element', element)
+    elements.push(element) // TODO: remove
 
     elVal =
       element.getBoundingClientRect()[side] +
@@ -928,7 +932,7 @@ ${Side} ${hasTags ? 'tagged ' : ''}element found at: ${maxVal}px
 Position calculated from HTML element: ${getElementName(maxEl)} (${elementSnippet(maxEl, 100)})`
 
   if (timer < PERF_TIME_LIMIT || len < PERF_MIN_ELEMENTS || hasTags || isInit) {
-    console.log(logMsg, elements)
+    console.log(logMsg, elements) // log(logMsg)
   } else if (perfWarned < timer && perfWarned < lastTimer) {
     perfWarned = timer * 1.2
     advise(

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -1,7 +1,7 @@
+import { HEIGHT_EDGE, OVERFLOW_ATTR } from '../common/consts'
 import { id } from '../common/utils'
 
-const OVERFLOW = 'data-iframe-overflow'
-let side = 'bottom'
+let side = HEIGHT_EDGE
 
 let onChange = id
 
@@ -20,10 +20,10 @@ const isTarget = (entry) =>
 
 const callback = (entries) => {
   entries.forEach((entry) => {
-    entry.target.toggleAttribute(OVERFLOW, isTarget(entry))
+    entry.target.toggleAttribute(OVERFLOW_ATTR, isTarget(entry))
   })
 
-  overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
+  overflowedElements = document.querySelectorAll(`[${OVERFLOW_ATTR}]`)
   onChange()
 }
 

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -1,0 +1,31 @@
+const options = {
+  root: document.documentElement,
+  rootMargin: '0px',
+  threshold: 1,
+}
+
+const overflowedElements = new WeakSet()
+const observedElements = new WeakSet()
+
+const callback = (entries) => {
+  entries.forEach((entry) => {
+    if (entry.intersectionRatio === 0) {
+      overflowedElements.add(entry.target)
+    } else {
+      overflowedElements.delete(entry.target)
+    }
+  })
+  console.log('overflowedElements', overflowedElements)
+}
+
+const observer = new IntersectionObserver(callback, options)
+
+export const observeOverflow = (nodeList) => {
+  nodeList.forEach((el) => {
+    if (observedElements.has(el)) return
+    observer.observe(el)
+    observedElements.add(el)
+  })
+}
+
+export const isOverflowed = (el) => overflowedElements.has(el)

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -3,7 +3,7 @@ import { id } from '../common/utils'
 const OVERFLOW = 'data-iframe-overflow'
 let side = 'bottom'
 
-let init = id
+let onChange = id
 
 const options = {
   root: document.documentElement,
@@ -24,14 +24,14 @@ const callback = (entries) => {
   })
 
   overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
-  init()
+  onChange()
 }
 
 const observer = new IntersectionObserver(callback, options)
 
 export const overflowObserver = (options) => {
   side = options.side
-  init = options.init
+  onChange = options.onChange
 
   return (nodeList) =>
     nodeList.forEach((el) => {

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -1,5 +1,5 @@
 const OVERFLOW = 'data-iframe-overflow'
-const side = 'bottom'
+let side = 'bottom'
 
 const options = {
   root: document.documentElement,
@@ -7,7 +7,7 @@ const options = {
   threshold: 1,
 }
 
-let overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
+let overflowedElements = []
 const observedElements = new WeakSet()
 
 const callback = (entries) => {
@@ -27,7 +27,11 @@ const callback = (entries) => {
 
 const observer = new IntersectionObserver(callback, options)
 
-export const observeOverflow = (nodeList) => {
+export const overflowObserver = (options) => (nodeList) => {
+  if (options && options.side) {
+    side = options.side
+  }
+
   nodeList.forEach((el) => {
     if (observedElements.has(el)) return
     observer.observe(el)

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -1,5 +1,9 @@
+import { id } from '../common/utils'
+
 const OVERFLOW = 'data-iframe-overflow'
 let side = 'bottom'
+
+let start = id
 
 const options = {
   root: document.documentElement,
@@ -7,7 +11,7 @@ const options = {
   threshold: 1,
 }
 
-let overflowedElements = []
+let overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
 const observedElements = new WeakSet()
 
 const callback = (entries) => {
@@ -16,29 +20,29 @@ const callback = (entries) => {
       entry.boundingClientRect[side] === 0 ||
       entry.boundingClientRect[side] >= entry.rootBounds[side]
     ) {
-      entry.target.setAttribute(OVERFLOW, true)
+      entry.target.toggleAttribute(OVERFLOW, true)
     } else {
       entry.target.removeAttribute(OVERFLOW)
     }
   })
   overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
-  // console.log('overflowed', overflowedElements)
+  start()
 }
 
 const observer = new IntersectionObserver(callback, options)
 
-export const overflowObserver = (options) => (nodeList) => {
-  if (options && options.side) {
-    side = options.side
-  }
+export const overflowObserver = (options) => {
+  side = options.side
+  start = options.start
 
-  nodeList.forEach((el) => {
-    if (observedElements.has(el)) return
-    observer.observe(el)
-    observedElements.add(el)
-  })
+  return (nodeList) =>
+    nodeList.forEach((el) => {
+      if (observedElements.has(el)) return
+      observer.observe(el)
+      observedElements.add(el)
+    })
 }
 
-export const isOverflowed = () => overflowedElements.length > 0
+export const isOverflowed = () => overflowedElements?.length > 0 || false
 
 export const getOverflowedElements = () => overflowedElements

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -1,21 +1,33 @@
+const OVERFLOW = 'data-iframe-overflow'
+const side = 'bottom'
+
 const options = {
   root: document.documentElement,
   rootMargin: '0px',
   threshold: 1,
 }
 
-const overflowedElements = new WeakSet()
+let overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
 const observedElements = new WeakSet()
 
 const callback = (entries) => {
   entries.forEach((entry) => {
-    if (entry.intersectionRatio === 0) {
-      overflowedElements.add(entry.target)
+    if (
+      entry.boundingClientRect[side] === 0 ||
+      entry.boundingClientRect[side] >= entry.rootBounds[side]
+    ) {
+      entry.target.setAttribute(OVERFLOW, true)
+      // console.log(
+      //   entry.target,
+      //   entry.boundingClientRect[side],
+      //   entry.rootBounds[side],
+      // )
     } else {
-      overflowedElements.delete(entry.target)
+      entry.target.removeAttribute(OVERFLOW)
     }
   })
-  console.log('overflowedElements', overflowedElements)
+  overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
+  console.log('overflowed', overflowedElements)
 }
 
 const observer = new IntersectionObserver(callback, options)
@@ -28,4 +40,6 @@ export const observeOverflow = (nodeList) => {
   })
 }
 
-export const isOverflowed = (el) => overflowedElements.has(el)
+export const isOverflowed = () => overflowedElements.length > 0
+
+export const getOverflowedElements = () => overflowedElements

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -17,17 +17,12 @@ const callback = (entries) => {
       entry.boundingClientRect[side] >= entry.rootBounds[side]
     ) {
       entry.target.setAttribute(OVERFLOW, true)
-      // console.log(
-      //   entry.target,
-      //   entry.boundingClientRect[side],
-      //   entry.rootBounds[side],
-      // )
     } else {
       entry.target.removeAttribute(OVERFLOW)
     }
   })
   overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
-  console.log('overflowed', overflowedElements)
+  // console.log('overflowed', overflowedElements)
 }
 
 const observer = new IntersectionObserver(callback, options)

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -11,7 +11,7 @@ const options = {
   threshold: 1,
 }
 
-let overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
+let overflowedElements = []
 const observedElements = new WeakSet()
 
 const callback = (entries) => {
@@ -43,6 +43,6 @@ export const overflowObserver = (options) => {
     })
 }
 
-export const isOverflowed = () => overflowedElements?.length > 0 || false
+export const isOverflowed = () => overflowedElements.length > 0
 
 export const getOverflowedElements = () => overflowedElements

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -16,7 +16,7 @@ const observedElements = new WeakSet()
 
 const isTarget = (entry) =>
   entry.boundingClientRect[side] === 0 ||
-  entry.boundingClientRect[side] >= entry.rootBounds[side]
+  entry.boundingClientRect[side] > entry.rootBounds[side]
 
 const callback = (entries) => {
   entries.forEach((entry) => {

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -14,17 +14,15 @@ const options = {
 let overflowedElements = []
 const observedElements = new WeakSet()
 
+const isTarget = (entry) =>
+  entry.boundingClientRect[side] === 0 ||
+  entry.boundingClientRect[side] >= entry.rootBounds[side]
+
 const callback = (entries) => {
   entries.forEach((entry) => {
-    if (
-      entry.boundingClientRect[side] === 0 ||
-      entry.boundingClientRect[side] >= entry.rootBounds[side]
-    ) {
-      entry.target.toggleAttribute(OVERFLOW, true)
-    } else {
-      entry.target.removeAttribute(OVERFLOW)
-    }
+    entry.target.toggleAttribute(OVERFLOW, isTarget(entry))
   })
+
   overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
   init()
 }

--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -3,7 +3,7 @@ import { id } from '../common/utils'
 const OVERFLOW = 'data-iframe-overflow'
 let side = 'bottom'
 
-let start = id
+let init = id
 
 const options = {
   root: document.documentElement,
@@ -26,14 +26,14 @@ const callback = (entries) => {
     }
   })
   overflowedElements = document.querySelectorAll(`[${OVERFLOW}]`)
-  start()
+  init()
 }
 
 const observer = new IntersectionObserver(callback, options)
 
 export const overflowObserver = (options) => {
   side = options.side
-  start = options.start
+  init = options.init
 
   return (nodeList) =>
     nodeList.forEach((el) => {

--- a/packages/common/consts.js
+++ b/packages/common/consts.js
@@ -2,7 +2,12 @@ export const VERSION = '[VI]{version}[/VI]'
 
 export const BASE = 10
 export const SINGLE = 1
+
 export const SIZE_ATTR = 'data-iframe-size'
+export const OVERFLOW_ATTR = 'data-iframe-overflow'
+
+export const HEIGHT_EDGE = 'bottom'
+export const WIDTH_EDGE = 'right'
 
 export const msgHeader = 'message'
 export const msgHeaderLen = msgHeader.length

--- a/packages/common/utils.js
+++ b/packages/common/utils.js
@@ -9,3 +9,5 @@ export const once = (fn) => {
       : ((done = true), Reflect.apply(fn, this, arguments))
   }
 }
+
+export const id = (x) => x


### PR DESCRIPTION
Create a NodeList  set of elements that overflow the document root. This improves downsizing perf, by greatly limiting the set of elements that we need to check the position of.