### PR TITLE
Added: Set location.hash when navigating inPageLinks

### DIFF
--- a/example/child/frame.absolute.html
+++ b/example/child/frame.absolute.html
@@ -25,7 +25,7 @@
         top: 0;
         right: 0;
         width: 100px;
-        height: 900px;
+        height: 1600px;
         background-color: wheat;
       }
       a.top {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -400,6 +400,8 @@ function iframeListener(event) {
       }
 
       scrollTo(iframeId)
+      window.location.hash = hash
+
       log(iframeId, '--')
     }
 


### PR DESCRIPTION
Set location.hash when navigating inPageLinks from child page to parent. This enables the browser back button to work correctly,

Based on feature request #1286