### PR TITLE
Babel runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.1.4",
       "license": "GPL-3.0",
       "dependencies": {
+        "@babel/runtime": "^7.24.7",
         "@iframe-resizer/child": "file:./packages/child/",
         "@iframe-resizer/core": "file:./packages/core/",
         "@iframe-resizer/parent": "file:./packages/parent/",
@@ -1886,10 +1887,10 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.6.tgz",
-      "integrity": "sha512-Ja18XcETdEl5mzzACGd+DKgaGJzPTCow7EglgwTmHdwokzDFYh/MHua6lU6DV/hjF2IaOJ4oX2nqnjG7RElKOw==",
-      "dev": true,
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -16898,8 +16899,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
     "url": "https://iframe-resizer.com/pricing/"
   },
   "dependencies": {
-    "@iframe-resizer/parent": "file:./packages/parent/",
+    "@babel/runtime": "^7.24.7",
     "@iframe-resizer/child": "file:./packages/child/",
     "@iframe-resizer/core": "file:./packages/core/",
+    "@iframe-resizer/parent": "file:./packages/parent/",
     "@iframe-resizer/react": "file:./packages/react/",
     "react": "^18.3.1",
     "warning": "^4.0.3"

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -195,7 +195,7 @@ function checkVersion() {
 
 Detected legacy version of parent page script. It is recommended to update the parent page to use <b>@iframe-resizer/parent</>.
 
-See <u>https://iframe-resizer.com/setup/<u> for more details.
+See <u>https://iframe-resizer.com/setup/</> for more details.
 `,
     )
     return


### PR DESCRIPTION
Add `@babel/runtime` to `@iframe-resizer/react` dependancies
Fix link in error version mismatch warning