### PR TITLE
Fixed: React Typings onInit -> onReady

### DIFF
--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -44,7 +44,7 @@ declare module '@iframe-resizer/react' {
     }
 
     type ResizerEvents = {
-      onInit?: (iframe: IFrameComponent) => void
+      onReady?: (iframe: IFrameComponent) => void
       onMessage?: (ev: { iframe: IFrameComponent; message: any }) => void
       onResized?: (ev: {
         iframe: IFrameComponent


### PR DESCRIPTION
Fix out of date typing.

React Typings`onInit` -> `onReady` 

#1294