### PR TITLE
Fix: Babel config for React Build

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -4,7 +4,13 @@ module.exports = {
     [
       '@babel/preset-env',
       {
-        targets: 'last 4 versions',
+        targets: [
+          'last 4 versions',
+          'Safari > 15',
+          'not dead',
+          'not < 0.25%',
+          'not ie 6-11',
+        ],
       },
     ],
     '@babel/preset-react',

--- a/example/react/package-lock.json
+++ b/example/react/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "react",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "dependencies": {
         "@iframe-resizer/child": "^5.1.5",
-        "@iframe-resizer/react": "^5.1.5",
+        "@iframe-resizer/core": "^5.2.1",
+        "@iframe-resizer/react": "^5.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -18,10 +19,10 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "eslint": "^8.57.0",
-        "eslint-plugin-react": "^7.34.3",
+        "eslint-plugin-react": "^7.34.4",
         "eslint-plugin-react-hooks": "^4.6.2",
-        "eslint-plugin-react-refresh": "^0.4.7",
-        "vite": "^5.3.3"
+        "eslint-plugin-react-refresh": "^0.4.8",
+        "vite": "^5.3.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -922,9 +923,9 @@
       }
     },
     "node_modules/@iframe-resizer/core": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@iframe-resizer/core/-/core-5.1.5.tgz",
-      "integrity": "sha512-uu0Ptk+R7vYY7R9HFsc5R4+p68rgGxrsWIq2sK9oanJPBtQ2P9pMYoRseM8F4AfOONHOeHxGByWeBmw7LTXmdA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@iframe-resizer/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-etPA5NfB+K9bALYME/d2k5AYdIKShUNyvJjMQ3HmHKHV4jNIxnqkzN0u6agsOUlwS7fMrRqy0btX0d3becf6Zw==",
       "license": "GPL-3.0",
       "funding": {
         "type": "individual",
@@ -932,13 +933,13 @@
       }
     },
     "node_modules/@iframe-resizer/react": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@iframe-resizer/react/-/react-5.1.5.tgz",
-      "integrity": "sha512-klGfad00ZiVHIplWYJ04ACp8vU6xa5ujLSWEJOFcc8SqQyJv7T0UtxuUGPiEXvSGeaP5HgFvYFzua7YOw/blIg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@iframe-resizer/react/-/react-5.2.1.tgz",
+      "integrity": "sha512-9y//81lit01jMQwT6nfeOdSh48tnS4luXaIcRkqa5oZdsAMnT0zAlGdnOh8yEjHLPmsBDsct5StY+wPlZOnyBg==",
       "license": "GPL-3.0",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
-        "@iframe-resizer/core": "5.1.5",
+        "@iframe-resizer/core": "5.2.1",
         "warning": "^4.0.3"
       },
       "funding": {
@@ -2195,9 +2196,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.34.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.3.tgz",
-      "integrity": "sha512-aoW4MV891jkUulwDApQbPYTVZmeuSyFrudpbTAQuj5Fv8VL+o6df2xIGpw8B0hPjAaih1/Fb0om9grCdyFYemA==",
+      "version": "7.34.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.34.4.tgz",
+      "integrity": "sha512-Np+jo9bUwJNxCsT12pXtrGhJgT3T44T1sHhn1Ssr42XFn8TES0267wPGo5nNrMHi8qkyimDAX2BUmkf9pSaVzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2209,16 +2210,17 @@
         "doctrine": "^2.1.0",
         "es-iterator-helpers": "^1.0.19",
         "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
         "object.entries": "^1.1.8",
         "object.fromentries": "^2.0.8",
-        "object.hasown": "^1.1.4",
         "object.values": "^1.2.0",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.5",
         "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.11"
+        "string.prototype.matchall": "^4.0.11",
+        "string.prototype.repeat": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
@@ -2241,9 +2243,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.7.tgz",
-      "integrity": "sha512-yrj+KInFmwuQS2UQcg1SF83ha1tuHC1jMQbRNyuWtlEzzKRDgAl7L4Yp4NlDUZTZNlWvHEzOtJhMi40R7JxcSw==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.8.tgz",
+      "integrity": "sha512-MIKAclwaDFIiYtVBLzDdm16E+Ty4GwhB6wZlCAG1R3Ur+F9Qbo6PRxpA5DK7XtDgm+WlCoAY2WxAwqhmIDHg6Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3588,24 +3590,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.hasown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
-      "integrity": "sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.0.tgz",
@@ -4207,6 +4191,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
@@ -4489,9 +4484,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
-      "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.4.tgz",
+      "integrity": "sha512-Cw+7zL3ZG9/NZBB8C+8QbQZmR54GwqIz+WMI4b3JgdYJvX+ny9AjJXqkGQlDXSXRP9rP0B4tbciRMOVEKulVOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/example/react/package-lock.json
+++ b/example/react/package-lock.json
@@ -8,9 +8,9 @@
       "name": "react",
       "version": "0.0.1",
       "dependencies": {
-        "@iframe-resizer/child": "^5.1.5",
+        "@iframe-resizer/child": "^5.2.2-beta.1",
         "@iframe-resizer/core": "^5.2.1",
-        "@iframe-resizer/react": "^5.2.1",
+        "@iframe-resizer/react": "^5.2.2-beta.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -913,9 +913,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@iframe-resizer/child": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@iframe-resizer/child/-/child-5.1.5.tgz",
-      "integrity": "sha512-VtFzsscLORASuWfEFi1jYNh4FES4CfARCtdESaXmR/37CNsfCfvbcW/nOJ+GbySWhYmKwitdYM6g3bWSbCoNlA==",
+      "version": "5.2.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@iframe-resizer/child/-/child-5.2.2-beta.1.tgz",
+      "integrity": "sha512-eXuEcvd58t5xJdL0pklphqFipgbAPO8V4wmScz1/H7CzdeW50l0fVeohA8NTLuxXaHbc3NaSZgIwU3ATlz8oEw==",
       "license": "GPL-3.0",
       "funding": {
         "type": "individual",
@@ -933,13 +933,13 @@
       }
     },
     "node_modules/@iframe-resizer/react": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@iframe-resizer/react/-/react-5.2.1.tgz",
-      "integrity": "sha512-9y//81lit01jMQwT6nfeOdSh48tnS4luXaIcRkqa5oZdsAMnT0zAlGdnOh8yEjHLPmsBDsct5StY+wPlZOnyBg==",
+      "version": "5.2.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@iframe-resizer/react/-/react-5.2.2-beta.1.tgz",
+      "integrity": "sha512-0fhMsmG6XwqOWS11bntbgl6Pz0exMSEGCFA2/SvgNSINp8ha5fTt5z1jC+SGj3V1rDhLgLYFWyGt17hFlr0WKA==",
       "license": "GPL-3.0",
       "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@iframe-resizer/core": "5.2.1",
+        "@babel/runtime": "^7.0.0",
+        "@iframe-resizer/core": "5.2.2-beta.1",
         "warning": "^4.0.3"
       },
       "funding": {
@@ -949,6 +949,16 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@iframe-resizer/react/node_modules/@iframe-resizer/core": {
+      "version": "5.2.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@iframe-resizer/core/-/core-5.2.2-beta.1.tgz",
+      "integrity": "sha512-xq/+5ncKO5OD+tdIATdKifKZsUw8BEOhUr+34GtWGae90R3W8OhcxKggdA0YFSxUvN41xN41pzJncebs/0kkbQ==",
+      "license": "GPL-3.0",
+      "funding": {
+        "type": "individual",
+        "url": "https://iframe-resizer.com/pricing/"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/example/react/package.json
+++ b/example/react/package.json
@@ -10,9 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@iframe-resizer/child": "^5.1.5",
+    "@iframe-resizer/child": "^5.2.2-beta.1",
     "@iframe-resizer/core": "^5.2.1",
-    "@iframe-resizer/react": "^5.2.1",
+    "@iframe-resizer/react": "^5.2.2-beta.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/example/react/package.json
+++ b/example/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@iframe-resizer/child": "^5.1.5",
-    "@iframe-resizer/react": "^5.1.5",
+    "@iframe-resizer/core": "^5.2.1",
+    "@iframe-resizer/react": "^5.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -20,9 +21,9 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^8.57.0",
-    "eslint-plugin-react": "^7.34.3",
+    "eslint-plugin-react": "^7.34.4",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-react-refresh": "^0.4.7",
-    "vite": "^5.3.3"
+    "eslint-plugin-react-refresh": "^0.4.8",
+    "vite": "^5.3.4"
   }
 }

--- a/example/react/package.json
+++ b/example/react/package.json
@@ -10,9 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@iframe-resizer/child": "^5.2.2-beta.1",
-    "@iframe-resizer/core": "^5.2.1",
-    "@iframe-resizer/react": "^5.2.2-beta.1",
+    "@iframe-resizer/child": "^5.2.2",
+    "@iframe-resizer/core": "^5.2.2",
+    "@iframe-resizer/react": "^5.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,10 +1941,7 @@
       "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
       "license": "MIT",
       "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "node_modules/@babel/template": {
@@ -8889,6 +8886,26 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/@babel/runtime": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eslint-plugin-lodash": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-lodash/-/eslint-plugin-lodash-7.4.0.tgz",
@@ -13778,6 +13795,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/json-fixer/node_modules/@babel/runtime": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/json-fixer/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -13835,6 +13865,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/json-fixer/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-fixer/node_modules/supports-color": {
       "version": "7.2.0",
@@ -17000,9 +17037,10 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -17012,6 +17050,26 @@
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
+    },
+    "node_modules/regenerator-transform/node_modules/@babel/runtime": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/regenerator-transform/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
@@ -17586,6 +17644,19 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/rollup-plugin-filesize/node_modules/@babel/runtime": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/rollup-plugin-filesize/node_modules/colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -17594,6 +17665,13 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/rollup-plugin-filesize/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup-plugin-generate-package-json": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iframe-resizer",
-  "version": "5.2.2",
+  "version": "5.2.2-beta.1",
   "private": true,
   "type": "module",
   "license": "GPL-3.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -178,7 +178,7 @@ const npm = [
         ...output('vue')('umd'),
       },
       output('vue')('esm'),
-      output('vue')('cjs')
+      output('vue')('cjs'),
     ],
     external: ['@iframe-resizer/core', 'vue'],
     plugins: [


### PR DESCRIPTION
The Babel config was supporting long dead browser, updated to only support ES2015 and up.