### PR TITLE
Added: Check for child script being loaded more than once

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -1366,10 +1366,14 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
     }
   }
 
-  window.iframeChildListener = (data) => receiver({ data, sameDomain: true })
-  addEventListener(window, 'message', receiver)
-  addEventListener(window, 'readystatechange', chkLateLoaded)
-  chkLateLoaded()
+  if ('iframeChildListener' in window) {
+    warn('Already setup')
+  } else {
+    window.iframeChildListener = (data) => receiver({ data, sameDomain: true })
+    addEventListener(window, 'message', receiver)
+    addEventListener(window, 'readystatechange', chkLateLoaded)
+    chkLateLoaded()
+  }
 
   /* TEST CODE START */
   function mockMsgListener(msgObject) {

--- a/packages/child/log.js
+++ b/packages/child/log.js
@@ -43,7 +43,8 @@ export function getElementName(el) {
 // }
 
 // TODO: remove .join(' '), requires major test updates
-const formatLogMsg = (...msg) => [`[iframe-resizer][${id}]`, ...msg].join(' ')
+const formatLogMsg = (...msg) =>
+  [`[iframe-resizer][${id || 'child'}]`, ...msg].join(' ')
 
 export const log = (...msg) =>
   // eslint-disable-next-line no-console


### PR DESCRIPTION
The child script should only be loaded once into the iframe. Added check to see if it has already been setup and return warning if this is the case.

Fixes: #1309 