### PR TITLE
Fixed: Case of child settings object

### DIFF
--- a/example/html/child/frame.animate.html
+++ b/example/html/child/frame.animate.html
@@ -116,7 +116,7 @@
       const rowParent = ([key, info]) =>
   `<tr><th>${key}</th><td><table>${Object.entries(info).map(row).join('\n')}</table></td></tr>`
 
-      window.iFrameResizer = {
+      window.iframeResizer = {
         // We cheat a little here, as the iframe resize can be one
         // frame behind the actual content height in the iframe if
         // we're having to use postMessage due to operating cross

--- a/example/html/child/frame.content.html
+++ b/example/html/child/frame.content.html
@@ -21,7 +21,7 @@
       }
     </script>
     <script>
-      window.iFrameResizer = {
+      window.iframeResizer = {
         onMessage(message) {
           alert(message, parentIFrame.getId())
         },

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -115,11 +115,10 @@ function iframeResizerChild() {
 
   function init() {
     readDataFromParent()
-    readDataFromPage()
-
-    log(`Initialising iFrame v${VERSION} (${window.location.href})`)
 
     setLogOptions({ id: myID, logging })
+    log(`Initialising iFrame v${VERSION} (${window.location.href})`)
+    readDataFromPage()
 
     checkCrossDomain()
     checkMode()
@@ -292,9 +291,15 @@ Parent page: ${version} - Child page: ${VERSION}.
 
     if (mode === 1) return
 
+    log(
+      'Read Data From Page:',
+      'iframeResizer' in window || 'iFrameResizer' in window,
+    )
+
     if (
-      'iFrameResizer' in window &&
-      Object === window.iFrameResizer.constructor
+      ('iFrameResizer' in window &&
+        Object === window.iFrameResizer.constructor) ||
+      ('iframeResizer' in window && Object === window.iframeResizer.constructor)
     ) {
       readData()
       heightCalcMode = setupCustomCalcMethods(heightCalcMode, 'height')

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -249,9 +249,7 @@ Parent page: ${version} - Child page: ${VERSION}.
 
   function readDataFromPage() {
     // eslint-disable-next-line sonarjs/cognitive-complexity
-    function readData() {
-      const data = window.iframeResizer || window.iFrameResizer
-
+    function readData(data) {
       log(`Reading data from page: ${JSON.stringify(data)}`)
 
       onMessage = data?.onMessage || onMessage
@@ -291,20 +289,13 @@ Parent page: ${version} - Child page: ${VERSION}.
 
     if (mode === 1) return
 
-    log(
-      'Read Data From Page:',
-      'iframeResizer' in window || 'iFrameResizer' in window,
-    )
+    const data = window.iframeResizer || window.iFrameResizer
 
-    if (
-      ('iFrameResizer' in window &&
-        Object === window.iFrameResizer.constructor) ||
-      ('iframeResizer' in window && Object === window.iframeResizer.constructor)
-    ) {
-      readData()
-      heightCalcMode = setupCustomCalcMethods(heightCalcMode, 'height')
-      widthCalcMode = setupCustomCalcMethods(widthCalcMode, 'width')
-    }
+    if (typeof data !== 'object') return
+
+    readData(data)
+    heightCalcMode = setupCustomCalcMethods(heightCalcMode, 'height')
+    widthCalcMode = setupCustomCalcMethods(widthCalcMode, 'width')
 
     log(`TargetOrigin for parent set to: ${targetOriginDefault}`)
   }


### PR DESCRIPTION
Fix case of child settings object to allow both `window.iframeResizer` and `window.iFrameResizer`.