### PR TITLE
Fixed: Stop pageInfo being double fired on parent page

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -229,9 +229,18 @@ function iframeListener(event) {
   }
 
   const startInfoMonitor = (sendInfoToIframe, type) => () => {
+    let pending = false
+
     const sendInfo = (requestType) => () => {
       if (settings[id]) {
-        sendInfoToIframe(requestType, id)
+        if (!pending || pending === requestType) {
+          sendInfoToIframe(requestType, id)
+
+          pending = requestType
+          requestAnimationFrame(() => {
+            pending = false
+          })
+        }
       } else {
         stop()
       }


### PR DESCRIPTION
Updates to `pageInfo` are detected by mutation observers on both the `body` and the `iframe` elements. When both detect changes, this ensures only one update message is send to the child page.