### PR TITLE
Use setTimeout(0) on events with void return type

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -156,7 +156,7 @@ function iframeResizerChild() {
 
     sendTitle()
     initEventListeners()
-    onReady()
+    setTimeout(onReady)
 
     log('Initialization complete')
     log('---')
@@ -1285,7 +1285,7 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
         const msgBody = getData()
         log(`PageInfo received from parent: ${msgBody}`)
         if (onPageInfo) {
-          onPageInfo(JSON.parse(msgBody))
+          setTimeout(() => onPageInfo(JSON.parse(msgBody)))
         } else {
           // not expected, so cancel more messages
           sendMsg(0, 0, 'pageInfoStop')
@@ -1297,7 +1297,7 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
         const msgBody = getData()
         log(`ParentInfo received from parent: ${msgBody}`)
         if (onParentInfo) {
-          onParentInfo(Object.freeze(JSON.parse(msgBody)))
+          setTimeout(onParentInfo(Object.freeze(JSON.parse(msgBody))))
         } else {
           // not expected, so cancel more messages
           sendMsg(0, 0, 'parentInfoStop')

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -676,13 +676,13 @@ function chkEvent(iframeId, funcName, val) {
   if (settings[iframeId]) {
     func = settings[iframeId][funcName]
 
-    if (typeof func === 'function') {
-      retVal = func(val)
-    } else {
+    if (typeof func === 'function')
+      if (funcName === 'onClose' || funcName === 'onScroll') retVal = func(val)
+      else setTimeout(() => func(val))
+    else
       throw new TypeError(
         `${funcName} on iFrame[${iframeId}] is not a function`,
       )
-    }
   }
 
   return retVal


### PR DESCRIPTION
Applies `setTimeout(0)` on events that don't return data to the library. This makes it easier to track events in the performance monitor and insulates the library from errors in user code.