### PR TITLE
Perf: Optimise resizerObservers setup

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -752,6 +752,17 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
   // This function has to iterate over all page elements during load
   // so is optimized for performance, rather than best practices.
   function attachResizeObserverToNonStaticElements(rootElement) {
+    if (rootElement.nodeType !== Node.ELEMENT_NODE) return
+
+    if (!resizeSet.has(rootElement)) {
+      const position = getComputedStyle(rootElement)?.position
+      if (!(position === '' || position === 'static')) {
+        resizeObserver.observe(rootElement)
+        resizeSet.add(rootElement)
+        log(`Attached resizeObserver: ${getElementName(rootElement)}`)
+      }
+    }
+
     const nodeList = getAllElements(rootElement)()
 
     // eslint-disable-next-line no-restricted-syntax

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -751,8 +751,8 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
 
   // This function has to iterate over all page elements during load
   // so is optimized for performance, rather than best practices.
-  function attachResizeObserverToNonStaticElements(el) {
-    const nodeList = getAllElements(el)()
+  function attachResizeObserverToNonStaticElements(rootElement) {
+    const nodeList = getAllElements(rootElement)()
 
     // eslint-disable-next-line no-restricted-syntax
     for (const node of nodeList) {

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -747,35 +747,30 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
     }, 0)
   }
 
-  const checkPositionType = (el) => {
-    if (el?.nodeType !== Node.ELEMENT_NODE) return false
-
-    const style = getComputedStyle(el)
-
-    return style?.position !== '' && style?.position !== 'static'
-  }
-
-  const attachResizeObserverToNonStaticElements = (el) => {
-    if (el?.nodeType !== Node.ELEMENT_NODE) return null
-
-    return [...getAllElements(el)()]
-      .filter(checkPositionType)
-      .forEach(setupResizeObserver)
-  }
-
   const resizeSet = new WeakSet()
 
-  function setupResizeObserver(el) {
-    if (resizeSet.has(el)) return
+  // This function has to iterate over all page elements during load
+  // so is optimized for performance, rather than best practices.
+  function attachResizeObserverToNonStaticElements(el) {
+    const nodeList = getAllElements(el)()
 
-    resizeObserver.observe(el)
-    resizeSet.add(el)
-    log(`Attached resizeObserver: ${getElementName(el)}`)
+    // eslint-disable-next-line no-restricted-syntax
+    for (const node of nodeList) {
+      if (resizeSet.has(node) || node?.nodeType !== Node.ELEMENT_NODE) continue // eslint-disable-line no-continue
+
+      const position = getComputedStyle(node)?.position
+      if (position === '' || position === 'static') continue // eslint-disable-line no-continue
+
+      resizeObserver.observe(node)
+      resizeSet.add(node)
+      log(`Attached resizeObserver: ${getElementName(node)}`)
+    }
   }
 
   function setupResizeObservers() {
     resizeObserver = new ResizeObserver(resizeObserved)
-    setupResizeObserver(document.body)
+    resizeObserver.observe(document.body)
+    resizeSet.add(document.body)
     attachResizeObserverToNonStaticElements(document.body)
   }
 

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -770,7 +770,6 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
   function setupResizeObservers() {
     resizeObserver = new ResizeObserver(resizeObserved)
     resizeObserver.observe(document.body)
-    resizeSet.add(document.body)
     attachResizeObserverToNonStaticElements(document.body)
   }
 


### PR DESCRIPTION
The setup routine for the `resizeObservers` to the child page has to iterate over all page elements during load so this change has optimised this code  for performance, over keeping **esLint** happy.

This change has removed extra function calls, by switching for `forEach()` to `for...of` and removing `filter()`. It has also reordered the checks on each node, so that the most efficient are performed first, in order to reduce the need for the more expensive checks.