### PR TITLE
Perf: Moved resize event throttle to capture all triggering events

### DIFF
--- a/packages/child/overflow.js
+++ b/packages/child/overflow.js
@@ -7,7 +7,6 @@ let overflowedElements = []
 export const overflowObserver = (options) => {
   const side = options.side || HEIGHT_EDGE
   const onChange = options.onChange || id
-  let onChangePending = false
 
   const observerOptions = {
     root: document.documentElement,
@@ -26,13 +25,11 @@ export const overflowObserver = (options) => {
       entry.target.toggleAttribute(OVERFLOW_ATTR, isTarget(entry))
     })
 
-    overflowedElements = document.querySelectorAll(`[${OVERFLOW_ATTR}]`)
-    log('overflowedElements:', overflowedElements.length)
-
-    if (onChangePending) return
-    onChangePending = true
+    // Call this on the next frame to allow the DOM to
+    // update and prevent reflowing the page
     requestAnimationFrame(() => {
-      onChangePending = false
+      overflowedElements = document.querySelectorAll(`[${OVERFLOW_ATTR}]`)
+      log('overflowedElements:', overflowedElements.length)
       onChange()
     })
   }


### PR DESCRIPTION
This change moves the resize event throttle to capture all resize events and eliminate double firing of the page content size calculations.

Events that are triggered as a result of content changes made by iframe-resizer, are delayed by one frame, to ensure they include the updated content.