### PR TITLE
Fixed: Disable parent props when requested to turn off stream

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -246,10 +246,13 @@ function iframeListener(event) {
       }
     }
 
+    const sendScroll = sendInfo('scroll')
+    const sendResize = sendInfo('resize window')
+
     function setListener(requestType, listener) {
       log(id, `${requestType} listeners for send${type}`)
-      listener(window, 'scroll', sendInfo('scroll'))
-      listener(window, 'resize', sendInfo('resize window'))
+      listener(window, 'scroll', sendScroll)
+      listener(window, 'resize', sendResize)
     }
 
     function stop() {


### PR DESCRIPTION
Fix bug where the event listeners for `getParentProps()` where not getting turned off after receiving a request from the iframe to no long receive this data.