### PR TITLE
Display content size calculation time

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "delog",
     "filesize",
     "iife",
+    "Initialised",
     "Initialising",
     "javascripts",
     "logcapture",

--- a/example/html/child/frame.content.html
+++ b/example/html/child/frame.content.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>iFrame message passing test</title>
+    <title>Iframe-Resizer Test Content</title>
     <meta name="description" content="iframe-resizer examples" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <script

--- a/example/html/index.html
+++ b/example/html/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>iFrame message passing test</title>
+    <title>Iframe-Resizer Examples</title>
     <meta name="description" content="iFrame message passing test" />
     <meta name="viewport" content="width=device-width" />
     <style>
@@ -66,7 +66,7 @@
       const iframes = iframeResize({
         inPageLinks: true,
         license: 'GPLv3',
-        log: true,
+        log: true, 
         waitForLoad: true,
 
         onResized(messageData) {

--- a/packages/child/log.js
+++ b/packages/child/log.js
@@ -53,7 +53,7 @@ export const log = (...msg) =>
 // eslint-disable-next-line no-unused-vars
 export const info = (...msg) =>
   // eslint-disable-next-line no-console
-  console?.info(`[iframe-resizer][${id}]`, ...msg)
+  logging && console?.info(`[iframe-resizer][${id}]`, ...msg)
 
 export const warn = (...msg) =>
   // eslint-disable-next-line no-console

--- a/packages/child/perf.js
+++ b/packages/child/perf.js
@@ -1,7 +1,7 @@
+import { round } from '../common/utils'
 import { advise, info, log } from './log'
 
 const SECOND = 1000
-const DEC_PLACES = 100_000 // 5 decimal places
 const PERF_CHECK_INTERVAL = 5 * SECOND
 const THRESHOLD = 4 // ms
 
@@ -13,7 +13,6 @@ const timings = []
 const usedTags = new WeakSet()
 
 const addUsedTag = (el) => typeof el === 'object' && usedTags.add(el)
-const round = (num) => Math.floor(num * DEC_PLACES) / DEC_PLACES
 
 let lastPerfEl = null
 let perfEl = null

--- a/packages/common/utils.js
+++ b/packages/common/utils.js
@@ -11,3 +11,7 @@ export const once = (fn) => {
 }
 
 export const id = (x) => x
+
+const ROUNDING = 100_000
+
+export const round = (value) => Math.round(value * ROUNDING) / ROUNDING


### PR DESCRIPTION
If the `log` option is set to **true** the display the time taken to calculate the new page content size.

Additionally messages sent to the parent and details of which element was used to calculate the page size, when falling back to either calculated overflowed elements or using `data-iframe-size`.