### PR TITLE
Return function in `getParentProps` typings

### DIFF
--- a/packages/child/index.d.ts
+++ b/packages/child/index.d.ts
@@ -53,7 +53,7 @@ declare module '@iframe-resizer/child' {
        *
        * Pass false to disable the callback.
        */
-      getParentProps(callback: (data: ParentProps) => void): void
+      getParentProps(callback: (data: ParentProps) => void): () => void
 
       /**
        * Scroll the parent page by x and y


### PR DESCRIPTION
According to the documentation `getParentProps` [returns a cleanup function](https://iframe-resizer.com/api/child/#getparentpropscallback)