### PR TITLE
Fix: null ref in perfObserver

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -901,8 +901,6 @@ The <b>size()</> method has been deprecated and replaced with  <b>resize()</>. U
       ? 0
       : document.documentElement.getBoundingClientRect().bottom
 
-    performance.mark(PREF_START)
-
     const targetElements = hasTags
       ? taggedElements
       : hasOverflow

--- a/packages/child/perf.js
+++ b/packages/child/perf.js
@@ -14,8 +14,8 @@ const usedTags = new WeakSet()
 
 const addUsedTag = (el) => typeof el === 'object' && usedTags.add(el)
 
-// let lastPerfEl = null
-let perfEl = null
+// let lastPerfEl
+let perfEl
 let details = {}
 
 export const setPerfEl = (el) => {

--- a/packages/child/perf.js
+++ b/packages/child/perf.js
@@ -14,8 +14,7 @@ const usedTags = new WeakSet()
 
 const addUsedTag = (el) => typeof el === 'object' && usedTags.add(el)
 
-// let lastPerfEl
-let perfEl
+let perfEl // = undefined
 let details = {}
 
 export const setPerfEl = (el) => {
@@ -28,15 +27,9 @@ function usedEl(detail, duration) {
 
   details = detail
 
-  if (
-    usedTags.has(perfEl) /* || lastPerfEl === perfEl */ ||
-    (hasTags && len <= 1)
-  )
-    return
+  if (usedTags.has(perfEl) || (hasTags && len <= 1)) return
 
   if (!logging) addUsedTag(perfEl)
-
-  // lastPerfEl = perfEl
 
   info(
     `\n  ${Side} position calculated from:`,


### PR DESCRIPTION
Fixes an issue when the child package is included more than once.