### PR TITLE
Add waitForLoad in react typings

### DIFF
--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -35,6 +35,7 @@ declare module '@iframe-resizer/react' {
       checkOrigin?: boolean | string[]
       direction?: 'vertical' | 'horizontal' | 'none'
       forwardRef?: any
+      waitForLoad?: boolean
       inPageLinks?: boolean
       license: string
       offset?: number


### PR DESCRIPTION
Currently, waitForLoad is missing in the typings used by the react library.

It works perfectly fine, this is just to fix the TS errors.