### PR TITLE
Fix: check window.matchMedia() is available for vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@iframe-resizer/core": "file:./packages/core/",
         "@iframe-resizer/parent": "file:./packages/parent/",
         "@iframe-resizer/react": "file:./packages/react/",
-        "auto-console-group": "1.2.0",
+        "auto-console-group": "1.2.1",
         "react": "^19.1.0"
       },
       "devDependencies": {
@@ -5097,8 +5097,8 @@
       "license": "MIT"
     },
     "node_modules/auto-console-group": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/auto-console-group/-/auto-console-group-1.2.0.tgz",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/auto-console-group/-/auto-console-group-1.2.1.tgz",
       "integrity": "sha512-rGes+R5TOv6IWI88NH4OoB5QqkkEnT/d6R+hj7lY1nXX6RFch10GJwaNFI7oOyt37ExTc/RAAIKvBErTZ5MV0w==",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@iframe-resizer/core": "file:./packages/core/",
     "@iframe-resizer/parent": "file:./packages/parent/",
     "@iframe-resizer/react": "file:./packages/react/",
-    "auto-console-group": "1.2.0",
+    "auto-console-group": "1.2.1",
     "react": "^19.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The **vitest** library does not fully mock `window`, so add check for `window.matchMedia()` before using it.

Fixes: #1415