### PR TITLE
Fix: Replace replaceAll with replace

### DIFF
--- a/packages/common/mode.js
+++ b/packages/common/mode.js
@@ -15,7 +15,7 @@ const l = (l) => {
     )
   },
   p = (l) =>
-    l.replaceAll(/[A-Za-z]/g, (l) =>
+    l.replace(/[A-Za-z]/g, (l) =>
       String.fromCodePoint(
         (l <= 'Z' ? 90 : 122) >= (l = l.codePointAt(0) + 19) ? l : l - 26,
       ),


### PR DESCRIPTION
Guard against incomplete `String.prototype.replaceAll()` polyfils.

When using a global regex, `String.replace()` and `String.replaceAll()` function identically, so we can use either method in this instance.

Fixes #1430 