### PR TITLE
Fix double fire parentProps when first requested

### DIFF
--- a/build/plugins.js
+++ b/build/plugins.js
@@ -29,16 +29,16 @@ export const pluginsBase = (stripLog) => (file) => {
 const fixVersion = (file) => {
   switch (file) {
     case 'core':
-      return {}
     case 'child':
-      return { additionalDependencies: { 'auto-console-group': pkg.dependencies['auto-console-group'] } }
+      return {}
+      // return { additionalDependencies: { 'auto-console-group': pkg.dependencies['auto-console-group'] } }
     case 'legacy':
       return {
         additionalDependencies: {
           '@iframe-resizer/child': pkg.version,
           '@iframe-resizer/jquery': pkg.version,
           '@iframe-resizer/parent': pkg.version,
-        }
+        },
       }
     default:
       return { additionalDependencies: { '@iframe-resizer/core': pkg.version } }

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -949,7 +949,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
 
       // Back off if the callStack is busy with other stuff
       if (delay > delayLimit && delay < DELAY_MAX) {
-        info('backed off due to heavy workload on callStack')
+        info('Backed off due to heavy workload on callStack')
         log(
           `%c${delay}ms %c>%c ${delayLimit}ms`,
           HIGHLIGHT,

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -1496,7 +1496,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
 
       pageInfo() {
         const msgBody = getData()
-        log(`PageInfo received from parent: ${msgBody}`)
+        log(`PageInfo received from parent:`, parseFrozen(msgBody))
         if (onPageInfo) {
           setTimeout(() => onPageInfo(parse(msgBody)))
         } else {
@@ -1505,10 +1505,10 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
       },
 
       parentInfo() {
-        const msgBody = getData()
-        log(`ParentInfo received from parent: ${msgBody}`)
+        const msgBody = parseFrozen(getData())
+        log(`ParentInfo received from parent:`, msgBody)
         if (onParentInfo) {
-          setTimeout(() => onParentInfo(parseFrozen(msgBody)))
+          setTimeout(() => onParentInfo(msgBody))
         } else {
           notExpected('parentInfo')
         }
@@ -1516,7 +1516,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
 
       message() {
         const msgBody = getData()
-        log(`onMessage called from parent: ${msgBody}`)
+        log(`onMessage called from parent:%c`, HIGHLIGHT, parseFrozen(msgBody))
         // eslint-disable-next-line sonarjs/no-extra-arguments
         setTimeout(() => onMessage(parse(msgBody)))
       },

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1,4 +1,4 @@
-import { FOREGROUND, HIGHLIGHT, ITALIC } from 'auto-console-group'
+import { FOREGROUND, HIGHLIGHT } from 'auto-console-group'
 
 import {
   EXPAND,
@@ -152,10 +152,11 @@ function iframeListener(event) {
   function forwardMsgFromIframe(msgBody) {
     log(
       iframeId,
-      `onMessage passed: {iframe: %c${messageData.iframe.id}%c, message: %c${msgBody}}`,
+      `onMessage passed: {iframe: %c${messageData.iframe.id}%c, message: %c${msgBody}%c}`,
       HIGHLIGHT,
       FOREGROUND,
-      ITALIC,
+      HIGHLIGHT,
+      FOREGROUND,
     )
 
     on('onMessage', {
@@ -523,11 +524,12 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
   }
 
   function eventMsg() {
+    const { height, iframe, msg, type, width } = messageData
     if (settings[iframeId]?.firstRun) firstRun()
 
-    switch (messageData.type) {
+    switch (type) {
       case 'close':
-        closeIframe(messageData.iframe)
+        closeIframe(iframe)
         break
 
       case 'message':
@@ -581,7 +583,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
         break
 
       case 'title':
-        setTitle(messageData.msg, iframeId)
+        setTitle(msg, iframeId)
         break
 
       case 'reset':
@@ -591,22 +593,22 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
       case 'init':
         resizeIframe()
         checkSameDomain(iframeId)
-        checkVersion(messageData.msg)
+        checkVersion(msg)
         started()
-        on('onReady', messageData.iframe)
+        on('onReady', iframe)
         break
 
       default:
-        if (messageData.width === 0 && messageData.height === 0) {
+        if (width === 0 && height === 0) {
           warn(
             iframeId,
-            `Unsupported message received (${messageData.type}), this is likely due to the iframe containing a later ` +
+            `Unsupported message received (${type}), this is likely due to the iframe containing a later ` +
               `version of iframe-resizer than the parent page`,
           )
           return
         }
 
-        if (messageData.width === 0 || messageData.height === 0) {
+        if (width === 0 || height === 0) {
           log(iframeId, 'Ignoring message with 0 height or width')
           return
         }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -561,12 +561,12 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
         break
 
       case 'pageInfo':
-        sendPageInfoToIframe('start', iframeId)
+        // sendPageInfoToIframe('start', iframeId)
         startPageInfoMonitor()
         break
 
       case 'parentInfo':
-        sendParentInfoToIframe('start', iframeId)
+        // sendParentInfoToIframe('start', iframeId)
         startParentInfoMonitor()
         break
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -58,21 +58,16 @@ const npm = [
     output: [
       {
         name: 'createResizer',
+        globals: {
+          'auto-console-group': 'createConsoleGroup',
+        },
         ...output('core')('umd'),
       },
       output('core')('esm'),
       output('core')('cjs'),
     ],
+    external: ['auto-console-group'],
     plugins: pluginsProd('core'),
-    watch: false,
-  },
-
-  //  Parent ES module (for bundlers) and CommonJS (for Node) build.
-  {
-    input: 'packages/parent/esm.js',
-    output: [output('parent')('esm'), output('parent')('cjs')],
-    external: ['@iframe-resizer/core'],
-    plugins: pluginsProd('parent'),
     watch: false,
   },
 
@@ -101,12 +96,12 @@ const npm = [
     ],
   },
 
-  //Child ES module (for bundlers) and CommonJS (for Node) build.
+  //  Parent ES module (for bundlers) and CommonJS (for Node) build.
   {
-    input: 'packages/child/index.js',
-    output: [output('child')('esm'), output('child')('cjs')],
-    external: ['auto-console-group'],
-    plugins: pluginsProd('child'),
+    input: 'packages/parent/esm.js',
+    output: [output('parent')('esm'), output('parent')('cjs')],
+    external: ['@iframe-resizer/core', 'auto-console-group'],
+    plugins: pluginsProd('parent'),
     watch: false,
   },
 
@@ -131,11 +126,20 @@ const npm = [
     watch: false,
   },
 
+  //Child ES module (for bundlers) and CommonJS (for Node) build.
+  {
+    input: 'packages/child/index.js',
+    output: [output('child')('esm'), output('child')('cjs')],
+    external: ['auto-console-group'],
+    plugins: pluginsProd('child'),
+    watch: false,
+  },
+
   //  jQuery (ES)
   {
     input: 'packages/jquery/plugin.js',
     output: [output('jquery')('esm'), output('jquery')('cjs')],
-    external: ['@iframe-resizer/core'],
+    external: ['@iframe-resizer/core', 'auto-console-group'],
     plugins: pluginsProd('parent'),
     watch: false,
   },
@@ -217,7 +221,12 @@ const npm = [
   {
     input: 'packages/react/index.jsx',
     output: [output('react')('esm'), output('react')('cjs')],
-    external: ['@iframe-resizer/core', 'react', /@babel\/runtime/],
+    external: [
+      '@iframe-resizer/core',
+      'auto-console-group',
+      'react',
+      /@babel\/runtime/,
+    ],
     plugins: [
       ...pluginsProd('react'),
       copy({
@@ -250,6 +259,11 @@ const npm = [
     input: 'packages/vue/index.js',
     output: [
       {
+        globals: {
+          'auto-console-group': 'createConsoleGroup',
+          '@iframe-resizer/core': 'connectResizer',
+          vue: 'Vue',
+        },
         name: 'IframeResizer',
         ...output('vue')('umd'),
       },


### PR DESCRIPTION
Prevent `parentIframe.getParentProps()` calling the callback twice when first invoked.