### PR TITLE
Fix CJS imports for `react` and `vue` versions

### DIFF
--- a/packages/react/index.jsx
+++ b/packages/react/index.jsx
@@ -1,8 +1,12 @@
 import connectResizer from '@iframe-resizer/core'
-import createAutoConsoleGroup from 'auto-console-group'
+import acg from 'auto-console-group'
 import React, { useEffect, useImperativeHandle, useRef } from 'react'
 
 import filterIframeAttribs from '../common/filter-iframe-attribs'
+import { esModuleInterop } from '../common/utils'
+
+// Deal with UMD not converting default exports to named exports
+const createAutoConsoleGroup = esModuleInterop(acg)
 
 // TODO: Add support for React.forwardRef() in next major version (Breaking change)
 function IframeResizer(props) {

--- a/packages/vue/iframe-resizer.vue
+++ b/packages/vue/iframe-resizer.vue
@@ -4,8 +4,13 @@
 
 <script>
   import connectResizer from '@iframe-resizer/core'
-  import autoConsoleGroup from 'auto-console-group'
+  import acg from 'auto-console-group'
 
+  import { esModuleInterop } from '../common/utils'
+
+  // Deal with UMD not converting default exports to named exports
+  const createAutoConsoleGroup = esModuleInterop(acg)
+  
   const EXPAND = 'expanded'
 
   export default {
@@ -84,7 +89,7 @@
         expand: options.logExpand, // set inside connectResizer
       }
 
-      const consoleGroup = autoConsoleGroup(consoleOptions)
+      const consoleGroup = createAutoConsoleGroup(consoleOptions)
       consoleGroup.event('setup')
       if (options.log) consoleGroup.log('Created Vue competent')
     },

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -59,7 +59,7 @@ const npm = [
       {
         name: 'createResizer',
         globals: {
-          'auto-console-group': 'createConsoleGroup',
+          'auto-console-group': 'acg',
         },
         ...output('core')('umd'),
       },
@@ -260,15 +260,15 @@ const npm = [
     output: [
       {
         globals: {
-          'auto-console-group': 'createConsoleGroup',
+          'auto-console-group': 'acg',
           '@iframe-resizer/core': 'connectResizer',
           vue: 'Vue',
         },
         name: 'IframeResizer',
         ...output('vue')('umd'),
       },
-      output('vue')('esm'),
       output('vue')('cjs'),
+      output('vue')('esm'),
     ],
     external: ['@iframe-resizer/core', 'vue', 'auto-console-group'],
     plugins: [


### PR DESCRIPTION
Fixes: #1442 