### PR TITLE
Fixed: Delay init when `readyState = 'loading'`

### DIFF
--- a/packages/child/console.js
+++ b/packages/child/console.js
@@ -33,6 +33,7 @@ export const {
   error,
   errorBoundary,
   event,
+  label,
   purge,
   warn,
 } = childConsole


### PR DESCRIPTION
When child script is asynchronous loaded, it could occasionally try to run init before the document was fully loaded, leading it to fail.