### PR TITLE
Fix (#1463) Filter descendants of ignored nodes

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -175,8 +175,12 @@ function iframeResizerChild() {
   }
 
   function checkOverflow() {
-    overflowedNodeList = document.querySelectorAll(
-      `[${OVERFLOW_ATTR}]:not([${IGNORE_ATTR}]):not([${IGNORE_ATTR}] *)`,
+    const allOverflowedNodes = document.querySelectorAll(`[${OVERFLOW_ATTR}]`)
+
+    // Filter out elements that are descendants of elements with IGNORE_ATTR
+    // eslint-disable-next-line unicorn/prefer-spread
+    overflowedNodeList = Array.from(allOverflowedNodes).filter(
+      (node) => !node.closest(`[${IGNORE_ATTR}]`),
     )
 
     hasOverflow = overflowedNodeList.length > 0


### PR DESCRIPTION
Replace _selector combinator_ with _descendant filter_ due to rare syntax error.