### PR TITLE
Delay `onReady` in child until browser readyState = complete

### DIFF
--- a/packages/common/utils.js
+++ b/packages/common/utils.js
@@ -1,5 +1,8 @@
 export const isNumber = (value) => !Number.isNaN(value)
 
+export const isolateUserCode = (func, ...val) =>
+  setTimeout(() => func(...val), 0)
+
 export const once = (fn) => {
   let done = false
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -14,7 +14,7 @@ import {
 } from '../common/consts'
 import { addEventListener, removeEventListener } from '../common/listeners'
 import setMode, { getModeData, getModeLabel } from '../common/mode'
-import { once, typeAssert } from '../common/utils'
+import { isolateUserCode, once, typeAssert } from '../common/utils'
 import {
   advise,
   // assert,
@@ -706,7 +706,7 @@ function chkEvent(iframeId, funcName, val) {
           console.error(error)
           warn(iframeId, `Error in ${funcName} callback`)
         }
-      } else setTimeout(() => func(val))
+      } else isolateUserCode(func, val)
     else
       throw new TypeError(
         `${funcName} on iFrame[${iframeId}] is not a function`,


### PR DESCRIPTION
Prevent the child `onReady` callback firing before the iframe `onLoad` event fires on the parent page to prevent a rare race condition.

Fixes: #1469 