### PR TITLE
Fix timeout  warning to catch errors caused by `waitForLoad: true`

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -568,12 +568,10 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
         break
 
       case 'pageInfo':
-        // sendPageInfoToIframe('start', iframeId)
         startPageInfoMonitor()
         break
 
       case 'parentInfo':
-        // sendParentInfoToIframe('start', iframeId)
         startParentInfoMonitor()
         break
 
@@ -855,10 +853,7 @@ function trigger(calleeMsg, msg, id) {
 
   consoleEvent(id, calleeMsg)
 
-  if (settings[id]) {
-    checkAndSend()
-    // if (noResponseWarning) warnOnNoResponse()
-  }
+  if (settings[id]) checkAndSend()
 }
 
 function createOutgoingMsg(iframeId) {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -33,6 +33,7 @@ import {
   vInfo,
   warn,
 } from './console'
+import warnOnNoResponse from './timeout'
 import defaults from './values/defaults'
 import page from './values/page'
 import settings from './values/settings'
@@ -816,7 +817,7 @@ const filterMsg = (msg) =>
     .filter((_, index) => index !== 19)
     .join(':')
 
-function trigger(calleeMsg, msg, id, noResponseWarning) {
+function trigger(calleeMsg, msg, id) {
   function logSent(route) {
     const displayMsg = calleeMsg in INIT_EVENTS ? filterMsg(msg) : msg
     info(id, route, HIGHLIGHT, FOREGROUND, HIGHLIGHT)
@@ -852,62 +853,11 @@ function trigger(calleeMsg, msg, id, noResponseWarning) {
     postMessageToIframe()
   }
 
-  function warnOnNoResponse() {
-    function warning() {
-      if (settings[id] === undefined) return // iframe has been closed while we where waiting
-
-      const { iframe, loaded, loadErrorShown, waitForLoad } = settings[id]
-
-      const { sandbox } = iframe
-
-      const hasSandbox = typeof sandbox === 'object' && sandbox.length > 0
-
-      if (!loaded && !loadErrorShown) {
-        settings[id].loadErrorShown = true
-        advise(
-          id,
-          `<rb>No response from iFrame</>
-            
-The iframe (<i>${id}</>) has not responded within ${settings[id].warningTimeout / 1000} seconds. Check <b>@iframe-resizer/child</> package has been loaded in the iframe.
-${
-  waitForLoad
-    ? `
-The <b>waitForLoad</> option is currently set to <i>'true'</>. If the iframe loads before the JavaScript runs, this option will prevent <i>iframe-resizer</> from initialising. To disable this, set the <b>waitForLoad</> option to <i>'false'</>.  
-`
-    : ''
-}${
-            hasSandbox &&
-            !(
-              sandbox.contains('allow-scripts') &&
-              sandbox.contains('allow-same-origin')
-            )
-              ? `
-The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
-`
-              : ''
-          } 
-${
-  hasSandbox &&
-  !(sandbox.contains('allow-scripts') && sandbox.contains('allow-same-origin'))
-    ? `The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
-`
-    : ''
-}This message can be ignored if everything is working, or you can set the <b>warningTimeout</> option to a higher value or zero to suppress this warning.
-`,
-        )
-      }
-    }
-
-    if (!!noResponseWarning && !!settings[id]?.warningTimeout) {
-      settings[id].msgTimeout = setTimeout(warning, settings[id].warningTimeout)
-    }
-  }
-
   consoleEvent(id, calleeMsg)
 
   if (settings[id]) {
     checkAndSend()
-    warnOnNoResponse()
+    // if (noResponseWarning) warnOnNoResponse()
   }
 }
 
@@ -1069,18 +1019,20 @@ Use of the <b>resize()</> method from the parent page is deprecated and will be 
   // event listener also catches the page changing in the iFrame.
   function init(msg) {
     function iFrameLoaded() {
-      trigger(ONLOAD, `${msg}:${setup}`, id, true)
+      trigger(ONLOAD, `${msg}:${setup}`, id)
       checkReset()
     }
 
     const { id } = iframe
     const { mode, waitForLoad } = settings[id]
 
+    warnOnNoResponse(id, settings)
+
     if (mode === -1) return // modal()
     if (mode === -2) return
 
     addEventListener(iframe, 'load', iFrameLoaded)
-    if (waitForLoad === false) trigger(INIT, `${msg}:${setup}`, id, true)
+    if (waitForLoad === false) trigger(INIT, `${msg}:${setup}`, id)
   }
 
   function checkOptions(options) {

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -26,14 +26,7 @@ The <b>waitForLoad</> option is currently set to <b>'true'</>. If the iframe loa
 The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
 `
         : ''
-    } 
-${
-  hasSandbox &&
-  !(sandbox.contains('allow-scripts') && sandbox.contains('allow-same-origin'))
-    ? `The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
-`
-    : ''
-}This message can be ignored if everything is working, or you can set the <b>warningTimeout</> option to a higher value or zero to suppress this warning.
+    }This message can be ignored if everything is working, or you can set the <b>warningTimeout</> option to a higher value or zero to suppress this warning.
 `,
   )
 }

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -1,0 +1,59 @@
+import { advise } from './console'
+
+function showWarning(id, settings) {
+  const { iframe, waitForLoad } = settings[id]
+  const { sandbox } = iframe
+  const hasSandbox = typeof sandbox === 'object' && sandbox.length > 0
+
+  advise(
+    id,
+    `<rb>No response from iFrame</>
+          
+The iframe (<i>${id}</>) has not responded within ${settings[id].warningTimeout / 1000} seconds. Check <b>@iframe-resizer/child</> package has been loaded in the iframe.
+${
+  waitForLoad
+    ? `
+The <b>waitForLoad</> option is currently set to <b>'true'</>. If the iframe loads before <i>iframe-resizer</> runs, this option will prevent <i>iframe-resizer</> initialising. To disable this option, set <b>waitForLoad</> to <b>'false'</>.  
+`
+    : ''
+}${
+      hasSandbox &&
+      !(
+        sandbox.contains('allow-scripts') &&
+        sandbox.contains('allow-same-origin')
+      )
+        ? `
+The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
+`
+        : ''
+    } 
+${
+  hasSandbox &&
+  !(sandbox.contains('allow-scripts') && sandbox.contains('allow-same-origin'))
+    ? `The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
+`
+    : ''
+}This message can be ignored if everything is working, or you can set the <b>warningTimeout</> option to a higher value or zero to suppress this warning.
+`,
+  )
+}
+
+export default function warnOnNoResponse(id, settings) {
+  function warning() {
+    if (settings[id] === undefined) return // iframe has been closed while we where waiting
+
+    const { loaded, loadErrorShown } = settings[id]
+
+    if (loaded) return
+    if (loadErrorShown) return
+
+    settings[id].loadErrorShown = true
+    showWarning(id, settings)
+  }
+
+  const { warningTimeout } = settings[id]
+
+  if (warningTimeout === 0) return
+
+  settings[id].msgTimeout = setTimeout(warning, warningTimeout)
+}

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -7,7 +7,7 @@ function showWarning(id, settings) {
 
   advise(
     id,
-    `<rb>No response from iFrame</>
+    `<rb>No response from iframe</>
           
 The iframe (<i>${id}</>) has not responded within ${settings[id].warningTimeout / 1000} seconds. Check <b>@iframe-resizer/child</> package has been loaded in the iframe.
 ${

--- a/packages/core/timeout.test.js
+++ b/packages/core/timeout.test.js
@@ -1,0 +1,113 @@
+import { jest } from '@jest/globals'
+
+import { advise } from './console'
+import warnOnNoResponse from './timeout'
+
+jest.mock('./console', () => ({
+  advise: jest.fn(),
+}))
+
+describe('warnOnNoResponse', () => {
+  let settings
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+
+    // Mocking iframe.sandbox as a DOMTokenList-like object
+    const mockSandbox = {
+      contains: jest.fn((value) =>
+        ['allow-scripts', 'allow-same-origin'].includes(value),
+      ),
+      length: 2, // Add a length property to simulate a valid sandbox
+    }
+
+    settings = {
+      iframe1: {
+        iframe: { sandbox: mockSandbox },
+        waitForLoad: false,
+        warningTimeout: 1000, // 1 second
+        loaded: false,
+        loadErrorShown: false,
+      },
+    }
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('should call advise with correct message when no sandbox issues', async () => {
+    warnOnNoResponse('iframe1', settings)
+    jest.runAllTimers() // Fast-forward all timers
+
+    expect(advise).toHaveBeenCalledWith(
+      'iframe1',
+      expect.stringContaining('No response from iframe'), // Updated to match actual string
+    )
+
+    expect(advise).toHaveBeenCalledWith(
+      'iframe1',
+      expect.not.stringContaining('The iframe has the <b>sandbox</> attribute'),
+    )
+  })
+
+  test('should include sandbox warning when sandbox is missing required attributes', async () => {
+    // Update the mock to simulate missing 'allow-same-origin'
+    settings.iframe1.iframe.sandbox.contains = jest.fn(
+      (value) => value === 'allow-scripts',
+    )
+
+    warnOnNoResponse('iframe1', settings)
+    jest.runAllTimers()
+
+    const expectedMessage = `
+      <rb>No response from iframe</> The iframe (<i>iframe1</>) has not responded within 1 seconds. Check <b>@iframe-resizer/child</> package has been loaded in the iframe.
+      The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
+      This message can be ignored if everything is working, or you can set the <b>warningTimeout</> option to a higher value or zero to suppress this warning.
+    `
+      .replace(/\s+/g, ' ')
+      .trim()
+
+    const receivedMessage = advise.mock.calls[0][1].replace(/\s+/g, ' ').trim()
+
+    expect(receivedMessage).toBe(expectedMessage)
+  })
+
+  test('should include waitForLoad warning when waitForLoad is true', async () => {
+    settings.iframe1.waitForLoad = true
+    warnOnNoResponse('iframe1', settings)
+    jest.runAllTimers()
+
+    expect(advise).toHaveBeenCalledWith(
+      'iframe1',
+      expect.stringContaining(
+        "The <b>waitForLoad</> option is currently set to <b>'true'</>.",
+      ),
+    )
+  })
+
+  test('should not include waitForLoad warning when waitForLoad is false', async () => {
+    settings.iframe1.waitForLoad = false
+    warnOnNoResponse('iframe1', settings)
+    jest.runAllTimers()
+
+    expect(advise).toHaveBeenCalledWith(
+      'iframe1',
+      expect.not.stringContaining(
+        "The <b>waitForLoad</> option is currently set to <b>'true'</>.",
+      ),
+    )
+  })
+
+  test('should calculate warningTimeout correctly in the message', async () => {
+    settings.iframe1.warningTimeout = 10_000 // 10 seconds
+    warnOnNoResponse('iframe1', settings)
+    jest.runAllTimers()
+
+    expect(advise).toHaveBeenCalledWith(
+      'iframe1',
+      expect.stringContaining('has not responded within 10 seconds'),
+    )
+  })
+})


### PR DESCRIPTION
When  `waitForLoad: true` the timeout function for no response needs to be invoked before the iframe's `onload` event fires.

Fixes: #1476