### PR TITLE
Fix: mutate text node

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -31,6 +31,7 @@ import {
   capitalizeFirstLetter,
   getElementName,
   isDef,
+  isElement,
   isolateUserCode,
   once,
   round,
@@ -979,7 +980,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
   }
 
   function attachObservers() {
-    const nodeList = getAllElements(document)()
+    const nodeList = getAllElements(document.documentElement)()
 
     log('Attaching Observers')
     createMutationObserver(mutationObserved)
@@ -1039,7 +1040,11 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     dimension.boundingClientRect(),
   ]
 
-  const getAllElements = (element) => () => {
+  const getAllElements = (node) => () => {
+    log('node:', node)
+    log('node type:', node?.nodeType)
+    if (!isElement(node)) return [node]
+
     const selector = [
       '* ',
       'not(head)',
@@ -1063,7 +1068,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     if (hasIgnored)
       selector.push(`not([${IGNORE_ATTR}])`, `not([${IGNORE_ATTR}] *)`)
 
-    return [element, ...element.querySelectorAll(selector.join(':'))]
+    return [node, ...node.querySelectorAll(selector.join(':'))]
   }
 
   function getOffsetSize(getDimension) {

--- a/packages/common/utils.js
+++ b/packages/common/utils.js
@@ -1,3 +1,5 @@
+export const isElement = (node) => node.nodeType === Node.ELEMENT_NODE
+
 export const isNumber = (value) => !Number.isNaN(value)
 
 export const isolateUserCode = (func, ...val) =>


### PR DESCRIPTION
Fix issue where mutating a text node would cause the add observer code to crash.