### PR TITLE
Improve warning on duplicate observers

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -33,7 +33,7 @@ import {
   getElementName,
   id,
   isDef,
-  isElement,
+  // isElement,
   isolateUserCode,
   once,
   round,
@@ -43,7 +43,6 @@ import checkBlockingCSS from './check-blocking-css'
 import {
   advise,
   adviser,
-  assert,
   // assert,
   debug,
   deprecateMethod,
@@ -183,6 +182,7 @@ function iframeResizerChild() {
       checkVersion,
       checkBoth,
       checkMode,
+      checkIgnoredElements,
       checkCrossDomain,
       checkHeightMode,
       checkWidthMode,
@@ -1064,16 +1064,12 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     dimension.boundingClientRect(),
   ]
 
-  const getAllElements = (node) => () => {
-    assert(isElement(node), 'getAllElements() requires a DOM element')
+  const addNot = (tag) => `:not(${tag})`
 
-    const selector = ['* ', ...[...IGNORE_TAGS].map((tag) => `not(${tag})`)]
-
-    if (checkIgnoredElements())
-      selector.push(`not([${IGNORE_ATTR}])`, `not([${IGNORE_ATTR}] *)`)
-
-    return [node, ...node.querySelectorAll(selector.join(':'))]
-  }
+  const getAllElements = (node) => () => [
+    node,
+    ...node.querySelectorAll(`* ${[...IGNORE_TAGS].map(addNot).join('')}`),
+  ]
 
   function getOffsetSize(getDimension) {
     const offset = getDimension.getOffset()

--- a/packages/child/observers/mutation.js
+++ b/packages/child/observers/mutation.js
@@ -2,7 +2,7 @@ import { FOREGROUND, HIGHLIGHT } from 'auto-console-group'
 
 import { IGNORE_ATTR, IGNORE_TAGS, SIZE_ATTR } from '../../common/consts'
 import { round } from '../../common/utils'
-import { event, info, log } from '../console'
+import { debug, event, info, log } from '../console'
 
 const DELAY = 16 // Corresponds to 60fps
 const DELAY_MARGIN = 2
@@ -37,6 +37,7 @@ function addedMutation(mutation) {
   for (const node of added) {
     if (shouldSkip(node)) continue
     addedNodes.add(node)
+    debug(`Added:`, node)
   }
 }
 
@@ -47,8 +48,10 @@ function removedMutation(mutation) {
     if (shouldSkip(node)) continue
     if (addedNodes.has(node)) {
       addedNodes.delete(node)
+      debug(`Removed (Added):`, node)
     } else {
       removedNodes.add(node)
+      debug(`Removed (Page):`, node)
     }
   }
 }
@@ -107,6 +110,7 @@ const createProcessMutations = (callback) => () => {
   pending = false
 
   logMutations()
+
   callback({ addedNodes, removedNodes })
 
   addedNodes.clear()

--- a/packages/child/observers/utils.js
+++ b/packages/child/observers/utils.js
@@ -1,6 +1,6 @@
 import { HIGHLIGHT, NORMAL } from 'auto-console-group'
 
-import { info } from '../console'
+import { debug, info, warn } from '../console'
 
 export const createLogCounter =
   (type, isAttach = true) =>
@@ -20,6 +20,7 @@ export const createDetachObservers =
 
     for (const node of nodeList) {
       if (!observed.has(node)) continue
+      debug(`Detaching ${type}Observer from:`, node)
       observer.unobserve(node)
       observed.delete(node)
       counter += 1
@@ -27,3 +28,14 @@ export const createDetachObservers =
 
     return counter
   }
+
+export const createWarnAlreadyObserved = (type) => (alreadyObserved) => {
+  if (alreadyObserved.size > 0) {
+    warn(
+      `${type} already attached to the following elements, skipping:\n\n`,
+      Array.from(alreadyObserved).flatMap((node) => ['\n', node]),
+    )
+  }
+
+  alreadyObserved.clear()
+}


### PR DESCRIPTION
Refactor multiple `assert()` into combined `warn()`