### PR TITLE
Fix: MutationThrottle causes duplicate elements to observer

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -966,7 +966,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     }
 
     info(`Inspecting:\n`, elements)
-    return Array.from(elements)
+    return elements
   }
 
   const addObservers = (nodeList) => {

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -958,23 +958,23 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     sendSize(VISIBILITY_OBSERVER, 'Visibility changed')
   }
 
-  const getCombinedElementLists = (nodeLists) => {
+  const getCombinedElementLists = (nodeList) => {
     const elements = new Set()
 
-    for (const nodeList of nodeLists) {
-      for (const element of getAllElements(nodeList)) elements.add(element)
+    for (const node of nodeList) {
+      for (const element of getAllElements(node)) elements.add(element)
     }
 
     info(`Inspecting:\n`, elements)
     return Array.from(elements)
   }
 
-  const addObservers = (nodeLists) => {
-    if (nodeLists.size === 0) return
+  const addObservers = (nodeList) => {
+    if (nodeList.size === 0) return
 
     consoleEvent('addObservers')
 
-    const elements = getCombinedElementLists(nodeLists)
+    const elements = getCombinedElementLists(nodeList)
 
     overflowObserver.attachObservers(elements)
     resizeObserver.attachObserverToNonStaticElements(elements)
@@ -982,12 +982,12 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     endAutoGroup()
   }
 
-  const removeObservers = (nodeLists) => {
-    if (nodeLists.size === 0) return
+  const removeObservers = (nodeList) => {
+    if (nodeList.size === 0) return
 
     consoleEvent('removeObservers')
 
-    const elements = getCombinedElementLists(nodeLists)
+    const elements = getCombinedElementLists(nodeList)
 
     overflowObserver.detachObservers(elements)
     resizeObserver.detachObservers(elements)

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -68,7 +68,6 @@ import createPerformanceObserver, {
   PREF_START,
 } from './observers/perf'
 import createResizeObserver from './observers/resize'
-import { createLogCounter } from './observers/utils'
 import createVisibilityObserver from './observers/visibility'
 import { readFunction, readNumber, readString } from './read'
 
@@ -905,11 +904,6 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     win.parentIFrame = win.parentIframe
   }
 
-  const logAddOverflow = createLogCounter('Overflow')
-  const logRemoveOverflow = createLogCounter('Overflow', false)
-  const logAddResize = createLogCounter('Resize')
-  const logRemoveResize = createLogCounter('Resize', false)
-
   function checkOverflow() {
     const allOverflowedNodes = document.querySelectorAll(`[${OVERFLOW_ATTR}]`)
 
@@ -944,8 +938,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
       overflowObserverOptions,
     )
 
-    const count = overflowObserver.attachObservers(nodeList)
-    logAddOverflow(count)
+    overflowObserver.attachObservers(nodeList)
   }
 
   function resizeObserved(entries) {
@@ -956,8 +949,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
 
   function createResizeObservers(nodeList) {
     resizeObserver = createResizeObserver(resizeObserved)
-    const count = resizeObserver.attachObserverToNonStaticElements(nodeList)
-    logAddResize(count)
+    resizeObserver.attachObserverToNonStaticElements(nodeList)
   }
 
   function visibilityChange(isVisible) {
@@ -973,6 +965,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
       for (const element of getAllElements(nodeList)) elements.add(element)
     }
 
+    info(`Inspecting:\n`, elements)
     return Array.from(elements)
   }
 
@@ -982,14 +975,9 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     consoleEvent('addObservers')
 
     const elements = getCombinedElementLists(nodeLists)
-    info(`Adding observers to:\n`, elements)
 
-    const addOverflowCount = overflowObserver.attachObservers(elements)
-    const addResizeCount =
-      resizeObserver.attachObserverToNonStaticElements(elements)
-
-    logAddOverflow(addOverflowCount)
-    logAddResize(addResizeCount)
+    overflowObserver.attachObservers(elements)
+    resizeObserver.attachObserverToNonStaticElements(elements)
 
     endAutoGroup()
   }
@@ -1000,13 +988,9 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     consoleEvent('removeObservers')
 
     const elements = getCombinedElementLists(nodeLists)
-    info(`Removing observers from:\n`, elements)
 
-    const removeOverflowCount = overflowObserver.detachObservers(elements)
-    const removeResizeCount = resizeObserver.detachObservers(elements)
-
-    logRemoveOverflow(removeOverflowCount)
-    logRemoveResize(removeResizeCount)
+    overflowObserver.detachObservers(elements)
+    resizeObserver.detachObservers(elements)
 
     endAutoGroup()
   }

--- a/packages/child/observers/overflow.js
+++ b/packages/child/observers/overflow.js
@@ -3,7 +3,7 @@ import { id } from '../../common/utils'
 import { debug } from '../console'
 import { createDetachObservers, createWarnAlreadyObserved } from './utils'
 
-const warningAlreadyObserved = createWarnAlreadyObserved('OverflowObserver')
+const warnAlreadyObserved = createWarnAlreadyObserved('OverflowObserver')
 
 const isHidden = (node) =>
   node.hidden || node.offsetParent === null || node.style.display === 'none'
@@ -45,11 +45,8 @@ const createOverflowObserver = (callback, options) => {
     let counter = 0
 
     for (const node of nodeList) {
-      const isObservable = node.nodeType === Node.ELEMENT_NODE
-      const isObserved = observed.has(node)
-
-      if (!isObservable) continue
-      if (isObserved) {
+      if (node.nodeType !== Node.ELEMENT_NODE) continue
+      if (observed.has(node)) {
         alreadyObserved.add(node)
         continue
       }
@@ -60,7 +57,7 @@ const createOverflowObserver = (callback, options) => {
       counter += 1
     }
 
-    warningAlreadyObserved(alreadyObserved)
+    warnAlreadyObserved(alreadyObserved)
     return counter
   }
 

--- a/packages/child/observers/resize.js
+++ b/packages/child/observers/resize.js
@@ -1,7 +1,7 @@
 import { debug, info } from '../console'
 import { createDetachObservers, createWarnAlreadyObserved } from './utils'
 
-const warningAlreadyObserved = createWarnAlreadyObserved('ResizeObserver')
+const warnAlreadyObserved = createWarnAlreadyObserved('ResizeObserver')
 const observed = new WeakSet()
 
 let observer
@@ -11,25 +11,23 @@ export function attachObserverToNonStaticElements(nodeList) {
   let counter = 0
 
   for (const node of nodeList) {
-    const isObservable = node.nodeType === Node.ELEMENT_NODE
-    const isObserved = observed.has(node)
-
-    if (!isObservable) continue
+    if (node.nodeType !== Node.ELEMENT_NODE) continue
 
     const position = getComputedStyle(node)?.position
     if (position === '' || position === 'static') continue
 
-    if (isObserved) {
+    if (observed.has(node)) {
       alreadyObserved.add(node)
       continue
     }
+
     debug(`Observing resize on:`, node)
     observer.observe(node)
     observed.add(node)
     counter += 1
   }
 
-  warningAlreadyObserved(alreadyObserved)
+  warnAlreadyObserved(alreadyObserved)
 
   return counter
 }

--- a/packages/child/observers/utils.js
+++ b/packages/child/observers/utils.js
@@ -2,6 +2,30 @@ import { HIGHLIGHT, NORMAL } from 'auto-console-group'
 
 import { debug, error, info } from '../console'
 
+export const metaCreateLogObserved =
+  (consoleType, text = '') =>
+  (type) =>
+  (observed) => {
+    if (observed.size > 0) {
+      consoleType(
+        `${type}Observer ${text}:`,
+        ...Array.from(observed).flatMap((node) => ['\n', node]),
+      )
+    }
+  }
+
+export const createLogNewlyObserved = metaCreateLogObserved(
+  debug,
+  'attached to',
+)
+
+export const createWarnAlreadyObserved = metaCreateLogObserved(
+  error,
+  'already attached',
+)
+
+const createLogNewlyRemoved = metaCreateLogObserved(info, 'detached from')
+
 export const createLogCounter =
   (type, isAttach = true) =>
   (counter) => {
@@ -15,27 +39,20 @@ export const createLogCounter =
   }
 
 export const createDetachObservers =
-  (type, observer, observed) => (nodeList) => {
+  (type, observer, observed, logCounter) => (nodeList) => {
+    const logNewlyRemoved = createLogNewlyRemoved(type)
+    const newlyRemoved = new Set()
     let counter = 0
 
     for (const node of nodeList) {
       if (!observed.has(node)) continue
-      debug(`Detaching ${type}Observer from:`, node)
       observer.unobserve(node)
       observed.delete(node)
+      newlyRemoved.add(node)
       counter += 1
     }
 
-    return counter
+    logNewlyRemoved(newlyRemoved)
+    logCounter(counter)
+    newlyRemoved.clear()
   }
-
-export const createWarnAlreadyObserved = (type) => (alreadyObserved) => {
-  if (alreadyObserved.size > 0) {
-    error(
-      `${type} already attached to the following elements:\n`,
-      Array.from(alreadyObserved).flatMap((node) => ['\n', node]),
-    )
-  }
-
-  alreadyObserved.clear()
-}

--- a/packages/child/observers/utils.js
+++ b/packages/child/observers/utils.js
@@ -38,9 +38,10 @@ export const createLogCounter =
     }
   }
 
-export const createDetachObservers =
-  (type, observer, observed, logCounter) => (nodeList) => {
-    const logNewlyRemoved = createLogNewlyRemoved(type)
+export const createDetachObservers = (type, observer, observed, logCounter) => {
+  const logNewlyRemoved = createLogNewlyRemoved(type)
+
+  return (nodeList) => {
     const newlyRemoved = new Set()
     let counter = 0
 
@@ -56,3 +57,4 @@ export const createDetachObservers =
     logCounter(counter)
     newlyRemoved.clear()
   }
+}

--- a/packages/child/observers/utils.js
+++ b/packages/child/observers/utils.js
@@ -1,6 +1,6 @@
 import { HIGHLIGHT, NORMAL } from 'auto-console-group'
 
-import { debug, info, warn } from '../console'
+import { debug, error, info } from '../console'
 
 export const createLogCounter =
   (type, isAttach = true) =>
@@ -31,8 +31,8 @@ export const createDetachObservers =
 
 export const createWarnAlreadyObserved = (type) => (alreadyObserved) => {
   if (alreadyObserved.size > 0) {
-    warn(
-      `${type} already attached to the following elements, skipping:\n\n`,
+    error(
+      `${type} already attached to the following elements:\n`,
       Array.from(alreadyObserved).flatMap((node) => ['\n', node]),
     )
   }


### PR DESCRIPTION
Merge `getAllElements()` call return values into a _Set_ when MutationObserver throttles and groups mutations

Fix:  #1488