### PR TITLE
Fix: Prevent erroneous error when width resizing with no tags or overflow

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -1037,7 +1037,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
       ? taggedElements
       : hasOverflow
         ? overflowedNodeList
-        : getAllElements(document) // We should never get here, but just in case
+        : getAllElements(document.documentElement) // Width resizing may need to check all elements
 
     for (const element of targetElements) {
       elVal =


### PR DESCRIPTION
 Prevent erroneous error message when width resizing with no tags or overflow