### PR TITLE
Delay late load message

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -1582,9 +1582,10 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
 
   // Normally the parent kicks things off when it detects the iFrame has loaded.
   // If this script is async-loaded, then tell parent page to retry init.
-  function chkLateLoaded() {
-    if (document.readyState !== 'loading') {
-      window.parent.postMessage('[iFrameResizerChild]Ready', '*')
+  function checkLateLoaded() {
+    if (document.readyState !== 'loading' && !firstRun) {
+      log('[iFrameResizerChild]Ready')
+      window.parent.postMessage(`[iFrameResizerChild]Ready`, '*')
     }
   }
 
@@ -1595,9 +1596,9 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
       setTimeout(() => received({ data, sameOrigin: true }))
 
     addEventListener(window, 'message', received)
-    addEventListener(window, 'readystatechange', chkLateLoaded)
+    addEventListener(window, 'readystatechange', checkLateLoaded)
 
-    chkLateLoaded()
+    setTimeout(checkLateLoaded)
   }
 
   /* TEST CODE START */


### PR DESCRIPTION
Push check late loaded on to event loop, rather than run instantly, in order to allow parent time to kickstart init.