### PR TITLE
Fix: Exclude `<html>` and `<body>` elements from observer list

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -1073,10 +1073,9 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     dimension.boundingClientRect(),
   ]
 
-  const addNot = (tag) => `:not(${tag})`
-
-  const getAllElements = (node) =>
-    node.querySelectorAll(`* ${[...IGNORE_TAGS].map(addNot).join('')}`)
+  const addNot = (tagName) => `:not(${tagName})`
+  const selector = `* ${[...IGNORE_TAGS].map(addNot).join('')}`
+  const getAllElements = (node) => node.querySelectorAll(selector)
 
   function getOffsetSize(getDimension) {
     const offset = getDimension.getOffset()

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -962,6 +962,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     const elements = new Set()
 
     for (const node of nodeList) {
+      elements.add(node)
       for (const element of getAllElements(node)) elements.add(element)
     }
 
@@ -1074,10 +1075,8 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
 
   const addNot = (tag) => `:not(${tag})`
 
-  const getAllElements = (node) => [
-    node,
-    ...node.querySelectorAll(`* ${[...IGNORE_TAGS].map(addNot).join('')}`),
-  ]
+  const getAllElements = (node) =>
+    node.querySelectorAll(`* ${[...IGNORE_TAGS].map(addNot).join('')}`)
 
   function getOffsetSize(getDimension) {
     const offset = getDimension.getOffset()

--- a/packages/common/consts.js
+++ b/packages/common/consts.js
@@ -70,7 +70,6 @@ export const LOG_OPTIONS = Object.freeze({
 })
 
 export const IGNORE_TAGS = new Set([
-  'html',
   'head',
   'body',
   'meta',

--- a/packages/common/consts.js
+++ b/packages/common/consts.js
@@ -70,7 +70,9 @@ export const LOG_OPTIONS = Object.freeze({
 })
 
 export const IGNORE_TAGS = new Set([
+  'html',
   'head',
+  'body',
   'meta',
   'base',
   'title',


### PR DESCRIPTION
Ensure `<html>` and `<body>` elements don't get past to the list of nodes checked for observers.