### PR TITLE
Fix: Delay warning timeout until after first message despatched 

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -643,7 +643,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
   }
 
   function initFromIframe(iframeId) {
-    if (settings[iframeId].loaded ) return
+    if (settings[iframeId].loaded) return
     trigger('iFrame requested init', createOutgoingMsg(iframeId), iframeId)
     warnOnNoResponse(iframeId, settings)
   }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -642,10 +642,14 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
     }
   }
 
+  function initFromIframe(iframeId) {
+    if (settings[iframeId].loaded) return
+    trigger('iFrame requested init', createOutgoingMsg(iframeId), iframeId)
+    warnOnNoResponse(iframeId, settings)
+  }
+
   function iFrameReadyMsgReceived() {
-    Object.keys(settings).forEach((iframeId) => {
-      trigger('iFrame requested init', createOutgoingMsg(iframeId), iframeId)
-    })
+    Object.keys(settings).forEach(initFromIframe)
   }
 
   function firstRun() {
@@ -674,7 +678,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
 
     if (!isMessageFromMetaParent()) {
       log(iframeId, `Received: %c${msg}`, HIGHLIGHT)
-      settings[iframeId].loaded = true
+      settings[iframeId].ready = true
 
       if (checkIframeExists() && isMessageFromIframe()) {
         eventMsg()
@@ -1039,16 +1043,22 @@ Use of the <b>resize()</> method from the parent page is deprecated and will be 
   function init(msg) {
     function iFrameLoaded() {
       trigger(ONLOAD, `${msg}:${setup}`, id)
+      settings[id].loaded = true
+      warnOnNoResponse(id, settings)
       checkReset()
     }
 
     const { id } = iframe
     const { waitForLoad } = settings[id]
 
-    warnOnNoResponse(id, settings)
-
     addEventListener(iframe, 'load', iFrameLoaded)
-    if (waitForLoad === false) trigger(INIT, `${msg}:${setup}`, id)
+
+    if (waitForLoad === true) return
+
+    // setTimeout(() => {
+    trigger(INIT, `${msg}:${setup}`, id)
+    warnOnNoResponse(id, settings)
+    // })
   }
 
   function checkOptions(options) {
@@ -1098,7 +1108,7 @@ The <b>sizeWidth</>, <b>sizeHeight</> and <b>autoResize</> options have been rep
         )
     }
 
-    log(iframeId, `Direction: %c${direction}`, HIGHLIGHT)
+    log(iframeId, `direction: %c${direction}`, HIGHLIGHT)
   }
 
   function setOffsetSize(offset) {
@@ -1146,9 +1156,31 @@ The <b>sizeWidth</>, <b>sizeHeight</> and <b>autoResize</> options have been rep
     }
   }
 
+  function checkWarningTimeout() {
+    if (!settings[iframeId].warningTimeout) {
+      info(iframeId, 'warningTimeout:%c disabled', HIGHLIGHT)
+    }
+  }
+
   const hasMouseEvents = (options) =>
     Object.hasOwn(options, 'onMouseEnter') ||
     Object.hasOwn(options, 'onMouseLeave')
+
+  function setTargetOrigin() {
+    settings[iframeId].targetOrigin =
+      settings[iframeId].checkOrigin === true
+        ? getTargetOrigin(settings[iframeId].remoteHost)
+        : '*'
+  }
+
+  function checkOffset(options) {
+    if (options?.offset) {
+      advise(
+        iframeId,
+        `<rb>Deprecated option</>\n\n The <b>offset</> option has been renamed to <b>offsetSize</>. Use of the old name will be removed in a future version of <i>iframe-resizer</>.`,
+      )
+    }
+  }
 
   function processOptions(options) {
     settings[iframeId] = {
@@ -1170,20 +1202,10 @@ The <b>sizeWidth</>, <b>sizeHeight</> and <b>autoResize</> options have been rep
     consoleEvent(iframeId, 'setup')
     setDirection()
     setOffsetSize(options?.offsetSize || options?.offset)
-
-    if (options?.offset) {
-      advise(
-        iframeId,
-        `<rb>Deprecated option</>\n\n The <b>offset</> option has been renamed to <b>offsetSize</>. Use of the old name will be removed in a future version of <i>iframe-resizer</>.`,
-      )
-    }
-
+    checkOffset(options)
+    checkWarningTimeout()
     getPostMessageTarget()
-
-    settings[iframeId].targetOrigin =
-      settings[iframeId].checkOrigin === true
-        ? getTargetOrigin(settings[iframeId].remoteHost)
-        : '*'
+    setTargetOrigin()
   }
 
   function setupIframe(options) {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -643,7 +643,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
   }
 
   function initFromIframe(iframeId) {
-    if (settings[iframeId].loaded) return
+    if (settings[iframeId].loaded ) return
     trigger('iFrame requested init', createOutgoingMsg(iframeId), iframeId)
     warnOnNoResponse(iframeId, settings)
   }
@@ -678,6 +678,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
 
     if (!isMessageFromMetaParent()) {
       log(iframeId, `Received: %c${msg}`, HIGHLIGHT)
+      settings[iframeId].loaded = true
       settings[iframeId].ready = true
 
       if (checkIframeExists() && isMessageFromIframe()) {
@@ -1055,10 +1056,8 @@ Use of the <b>resize()</> method from the parent page is deprecated and will be 
 
     if (waitForLoad === true) return
 
-    // setTimeout(() => {
     trigger(INIT, `${msg}:${setup}`, id)
     warnOnNoResponse(id, settings)
-    // })
   }
 
   function checkOptions(options) {

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -1,4 +1,4 @@
-import { advise } from './console'
+import { advise, event } from './console'
 
 function showWarning(id, settings) {
   const { iframe, waitForLoad } = settings[id]
@@ -10,6 +10,7 @@ function showWarning(id, settings) {
       sandbox.contains('allow-scripts') && sandbox.contains('allow-same-origin')
     )
 
+  event(id, 'noResponse')
   advise(
     id,
     `<rb>No response from iframe</>
@@ -37,18 +38,19 @@ export default function warnOnNoResponse(id, settings) {
   function warning() {
     if (settings[id] === undefined) return // iframe has been closed while we where waiting
 
-    const { loaded, loadErrorShown } = settings[id]
+    const { ready, loadErrorShown } = settings[id]
 
-    if (loaded) return
-    if (loadErrorShown) return
+    settings[id].msgTimeout = undefined
+
+    if (ready || loadErrorShown) return
 
     settings[id].loadErrorShown = true
     showWarning(id, settings)
   }
 
-  const { warningTimeout } = settings[id]
+  const { msgTimeout, warningTimeout } = settings[id]
 
-  if (warningTimeout === 0) return
+  if (msgTimeout || !warningTimeout) return
 
   settings[id].msgTimeout = setTimeout(warning, warningTimeout)
 }

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -50,7 +50,8 @@ export default function warnOnNoResponse(id, settings) {
 
   const { msgTimeout, warningTimeout } = settings[id]
 
-  if (msgTimeout || !warningTimeout) return
+  if (!warningTimeout) return
+  if (msgTimeout) clearTimeout(msgTimeout)
 
   settings[id].msgTimeout = setTimeout(warning, warningTimeout)
 }

--- a/packages/core/timeout.test.js
+++ b/packages/core/timeout.test.js
@@ -1,10 +1,11 @@
 import { jest } from '@jest/globals'
 
-import { advise } from './console'
+import { advise, event } from './console'
 import warnOnNoResponse from './timeout'
 
 jest.mock('./console', () => ({
   advise: jest.fn(),
+  event: jest.fn(),
 }))
 
 describe('warnOnNoResponse', () => {
@@ -41,9 +42,11 @@ describe('warnOnNoResponse', () => {
     warnOnNoResponse('iframe1', settings)
     jest.runAllTimers() // Fast-forward all timers
 
+    expect(event).toHaveBeenCalledWith('iframe1', 'noResponse')
+
     expect(advise).toHaveBeenCalledWith(
       'iframe1',
-      expect.stringContaining('No response from iframe'), // Updated to match actual string
+      expect.stringContaining('No response from iframe'),
     )
 
     expect(advise).toHaveBeenCalledWith(

--- a/packages/core/timeout.test.js
+++ b/packages/core/timeout.test.js
@@ -27,7 +27,7 @@ describe('warnOnNoResponse', () => {
         iframe: { sandbox: mockSandbox },
         waitForLoad: false,
         warningTimeout: 1000, // 1 second
-        loaded: false,
+        ready: false,
         loadErrorShown: false,
       },
     }


### PR DESCRIPTION
Don't start warning timeout until after first message sent to iframe