### PR TITLE
Fix: Cross origin initialisation of hidden iframes fails

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -18,6 +18,7 @@ import {
   OVERFLOW_OBSERVER,
   PARENT_RESIZE_REQUEST,
   RESIZE_OBSERVER,
+  RESUME_OBSERVER,
   SET_OFFSET_SIZE,
   SIZE_ATTR,
   SIZE_CHANGE_DETECTED,
@@ -68,6 +69,7 @@ import createPerformanceObserver, {
   PREF_START,
 } from './observers/perf'
 import createResizeObserver from './observers/resize'
+import createResumeObserver from './observers/resume'
 import createVisibilityObserver from './observers/visibility'
 import { readFunction, readNumber, readString } from './read'
 
@@ -1297,6 +1299,8 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
 
     switch (updateEvent) {
       case INIT:
+        if (newHeight === 0 && newWidth === 0) return // hidden
+      // eslint-disable-next-line no-fallthrough
       case ENABLE:
       case SIZE_CHANGE_DETECTED:
         // lockTrigger()


### PR DESCRIPTION
When a hidden cross origin iframe is initialised its size is reported as `0, 0`. This then prevents the iframe resizing when it is later unhidden.