### PR TITLE
Fix: Filter false positives from OverflowObserver

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -924,11 +924,11 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${type} c
     switch (true) {
       case falsePositive:
         return
-      
+
       case overflowedNodeList.length > 1:
         info('Overflowed Elements:', ...overflowedNodeList)
         break
-      
+
       case hasOverflow:
         break
 


### PR DESCRIPTION
Replacing a node with no overflow triggers the overflowObserver. Catch and filter these events.