### PR TITLE
Filter false positives from overflowObserver

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -916,10 +916,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${label} 
 
     if (ignoredNodeSet.size > 0) {
       consoleEvent('overflowIgnored')
-      info(
-        `Ignoring elements with [data-iframe-ignore] > *:\n`,
-        ignoredNodeSet,
-      )
+      info(`Ignoring elements with [data-iframe-ignore] > *:\n`, ignoredNodeSet)
       endAutoGroup()
     }
 


### PR DESCRIPTION
This PR filters false positives from the overflow observer by only triggering events when the overflow state actually changes. The implementation compares the before and after sets of overflowed elements using symmetric difference to detect real changes, preventing unnecessary resize events when nodes are replaced without overflow changes.

* Replaces array-based overflow tracking with Set-based tracking for better performance
* Adds overflow change detection using symmetric difference comparison
* Introduces logging for elements ignored via `data-iframe-ignore` attribute