### PR TITLE
Reset ready state on parent page when navigating to new page in the iframe

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -228,7 +228,6 @@ function iframeResizerChild() {
   function beforeUnload() {
     addEventListener(window, 'beforeunload', () => {
       tearDown.forEach((func) => func())
-      manageEventListeners('remove')
       sendMsg(0, 0, 'beforeUnload')
     })
   }
@@ -609,7 +608,9 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${label} 
     if (autoResize !== true) {
       log('Auto Resize disabled')
     }
+
     manageEventListeners('add')
+    tearDown.push(() => manageEventListeners('remove'))
   }
 
   function injectClearFixIntoBodyElement() {

--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -101,6 +101,7 @@ function iframeResizerChild() {
   // const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
   const msgID = '[iFrameSizer]' // Must match host page msg ID
   const msgIdLen = msgID.length
+  const tearDown = []
   const widthCalcModeDefault = 'scroll'
 
   let autoResize = true
@@ -205,6 +206,7 @@ function iframeResizerChild() {
 
       initEventListeners,
       attachObservers,
+      beforeUnload,
     ]
 
     isolate(setup)
@@ -221,6 +223,14 @@ function iframeResizerChild() {
     )
 
     sendTitle()
+  }
+
+  function beforeUnload() {
+    addEventListener(window, 'beforeunload', () => {
+      tearDown.forEach((func) => func())
+      manageEventListeners('remove')
+      sendMsg(0, 0, 'beforeUnload')
+    })
   }
 
   function checkReadyYet(readyCallback) {
@@ -985,6 +995,8 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${label} 
     )
 
     overflowObserver.attachObservers(nodeList)
+
+    return overflowObserver
   }
 
   function resizeObserved(entries) {
@@ -996,6 +1008,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${label} 
   function createResizeObservers(nodeList) {
     resizeObserver = createResizeObserver(resizeObserved)
     resizeObserver.attachObserverToNonStaticElements(nodeList)
+    return resizeObserver
   }
 
   function visibilityChange(isVisible) {
@@ -1058,15 +1071,23 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${label} 
     sendSize(MUTATION_OBSERVER, 'Mutation Observed')
   }
 
+  function pushDisconnectsOnToTearDown(observers) {
+    tearDown.push(...observers.map((observer) => observer.disconnect))
+  }
+
   function attachObservers() {
     const nodeList = getAllElements(document.documentElement)
 
     log('Attaching Observers')
-    createMutationObserver(mutationObserved)
-    createOverflowObservers(nodeList)
-    createPerformanceObserver()
-    createResizeObservers(nodeList)
-    createVisibilityObserver(visibilityChange)
+    const observers = [
+      createMutationObserver(mutationObserved),
+      createOverflowObservers(nodeList),
+      createPerformanceObserver(),
+      createResizeObservers(nodeList),
+      createVisibilityObserver(visibilityChange),
+    ]
+
+    pushDisconnectsOnToTearDown(observers)
   }
 
   function getMaxElement(side) {

--- a/packages/child/observers/mutation.js
+++ b/packages/child/observers/mutation.js
@@ -146,5 +146,14 @@ export default function createMutationObserver(callback) {
 
   info('Attached MutationObserver to body')
 
-  return observer
+  return {
+    ...observer,
+    disconnect: () => {
+      addedNodes.clear()
+      removedNodes.clear()
+      newMutations.length = 0
+      observer.disconnect()
+      info('Detached MutationObserver')
+    },
+  }
 }

--- a/packages/child/observers/overflow.js
+++ b/packages/child/observers/overflow.js
@@ -37,6 +37,7 @@ const createOverflowObserver = (callback, options) => {
   function observation(entries) {
     for (const entry of entries) {
       const { boundingClientRect, rootBounds, target } = entry
+      if (!rootBounds) continue // guard
       const edge = boundingClientRect[side]
       const hasOverflow = isOverflowed(edge, rootBounds) && !isHidden(target)
 

--- a/packages/child/observers/overflow.js
+++ b/packages/child/observers/overflow.js
@@ -1,5 +1,6 @@
 import { HEIGHT_EDGE, OVERFLOW_ATTR } from '../../common/consts'
 import { id } from '../../common/utils'
+import { info } from '../console'
 import {
   createDetachObservers,
   createLogCounter,
@@ -82,6 +83,10 @@ const createOverflowObserver = (callback, options) => {
       observed,
       logRemoveOverflow,
     ),
+    disconnect: () => {
+      observer.disconnect()
+      info('Detached OverflowObserver')
+    },
   }
 }
 

--- a/packages/child/observers/perf.js
+++ b/packages/child/observers/perf.js
@@ -45,9 +45,9 @@ function startTimingCheck() {
     if (roundedAverage > oldAverage) {
       oldAverage = roundedAverage
       event('performanceObserver')
-      log('Median time:', round(timings[Math.floor(timings.length / 2)]))
+      log('Mean time:', round(timings[Math.floor(timings.length / 2)]))
       log(
-        'Mean time:',
+        'Median time:',
         round(timings.reduce((a, b) => a + b, 0) / timings.length),
       )
       log('Average time:', roundedAverage)

--- a/packages/child/observers/perf.js
+++ b/packages/child/observers/perf.js
@@ -4,15 +4,17 @@ import { advise, event, info, log } from '../console'
 const SECOND = 1000
 const PERF_CHECK_INTERVAL = 5 * SECOND
 const THRESHOLD = 4 // ms
+const MIN_SAMPLES = 10
+const MAX_SAMPLES = 100
 
 export const PREF_START = '--ifr-start'
 export const PREF_END = '--ifr-end'
 const PREF_MEASURE = '--ifr-measure'
 
 const timings = []
-const usedTags = new WeakSet()
+// const usedTags = new WeakSet()
 
-const addUsedTag = (el) => typeof el === 'object' && usedTags.add(el)
+// const addUsedTag = (el) => typeof el === 'object' && usedTags.add(el)
 
 let detail = {}
 let oldAverage = 0
@@ -30,7 +32,7 @@ function clearPerfMarks() {
 
 function startTimingCheck() {
   timingCheckId = setInterval(() => {
-    if (timings.length < 10) return
+    if (timings.length < MIN_SAMPLES) return
     if (detail.hasTags && detail.len < 25) return
 
     timings.sort()
@@ -82,7 +84,7 @@ function perfObserver(list) {
       )
       detail = entry.detail
       timings.push(duration)
-      if (timings.length > 100) timings.shift()
+      if (timings.length > MAX_SAMPLES) timings.shift()
     } catch {
       // Missing marks; ignore
     }
@@ -94,8 +96,8 @@ export default function createPerformanceObserver() {
   const observer = new PerformanceObserver(perfObserver)
   observer.observe({ entryTypes: ['mark'] })
 
-  addUsedTag(document.documentElement)
-  addUsedTag(document.body)
+  // addUsedTag(document.documentElement)
+  // addUsedTag(document.body)
 
   startTimingCheck()
 

--- a/packages/child/observers/resize.js
+++ b/packages/child/observers/resize.js
@@ -12,12 +12,12 @@ const logRemoveResize = createLogCounter(RESIZE, false)
 const logNewlyObserved = createLogNewlyObserved(RESIZE)
 const warnAlreadyObserved = createWarnAlreadyObserved(RESIZE)
 const observed = new WeakSet()
+const alreadyObserved = new Set()
+const newlyObserved = new Set()
 
 let observer
 
 export function attachObserverToNonStaticElements(nodeList) {
-  const alreadyObserved = new Set()
-  const newlyObserved = new Set()
   let counter = 0
 
   for (const node of nodeList) {

--- a/packages/child/observers/resize.js
+++ b/packages/child/observers/resize.js
@@ -59,5 +59,9 @@ export default (callback) => {
       observed,
       logRemoveResize,
     ),
+    disconnect: () => {
+      observer.disconnect()
+      info('Detached ResizeObserver')
+    },
   }
 }

--- a/packages/child/observers/utils.js
+++ b/packages/child/observers/utils.js
@@ -33,9 +33,6 @@ export const createWarnAlreadyObserved =
 
 const createLogNewlyRemoved = metaCreateDebugObserved('detached from')
 
-export const watchUnload = (observer) =>
-  window.addEventListener('beforeunload', () => observer.disconnect())
-
 export const createLogCounter =
   (type, isAttach = true) =>
   (counter) => {

--- a/packages/child/observers/utils.js
+++ b/packages/child/observers/utils.js
@@ -33,6 +33,9 @@ export const createWarnAlreadyObserved =
 
 const createLogNewlyRemoved = metaCreateDebugObserved('detached from')
 
+export const watchUnload = (observer) =>
+  window.addEventListener('beforeunload', () => observer.disconnect())
+
 export const createLogCounter =
   (type, isAttach = true) =>
   (counter) => {

--- a/packages/child/observers/visibility.js
+++ b/packages/child/observers/visibility.js
@@ -12,4 +12,11 @@ export default function visibilityObserver(callback) {
   observer.observe(target)
 
   info('Attached VisibilityObserver to page')
+
+  return {
+    disconnect: () => {
+      observer.disconnect()
+      info('Detached VisibilityObserver')
+    },
+  }
 }

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -556,6 +556,11 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
         onMouse('onMouseLeave')
         break
 
+      case 'beforeUnload':
+        info(iframeId, 'Ready state reset')
+        settings[iframeId].ready = false
+        break
+
       case 'autoResize':
         settings[iframeId].autoResize = JSON.parse(getMsgBody(9))
         break
@@ -643,7 +648,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
   }
 
   function initFromIframe(iframeId) {
-    if (settings[iframeId].loaded) return
+    if (settings[iframeId].ready) return
     trigger('iframe requested init', createOutgoingMsg(iframeId), iframeId)
     warnOnNoResponse(iframeId, settings)
   }
@@ -678,7 +683,6 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
 
     if (!isMessageFromMetaParent()) {
       log(iframeId, `Received: %c${msg}`, HIGHLIGHT)
-      settings[iframeId].loaded = true
       settings[iframeId].ready = true
 
       if (checkIframeExists() && isMessageFromIframe()) {
@@ -1042,9 +1046,8 @@ Use of the <b>resize()</> method from the parent page is deprecated and will be 
   // iframes have completed loading when this code runs. The
   // event listener also catches the page changing in the iFrame.
   function init(msg) {
-    function iFrameLoaded() {
+    const iFrameLoaded = () => {
       trigger(ONLOAD, `${msg}:${setup}`, id)
-      settings[id].loaded = true
       warnOnNoResponse(id, settings)
       checkReset()
     }


### PR DESCRIPTION
Added `beforeUnload` event in child, in order to tell the parent to reset the ready state of the parent. This allows us to turn back on the `warningTimeout` for the next page that loads into the iframe.

While we are here we can also disconnect the observers in case they slow down then transition to the next page.