### PR TITLE
Fix: Attach `readystataechange` listener to `document` instead of `window`

### DIFF
--- a/packages/child/index.js
+++ b/packages/child/index.js
@@ -1703,7 +1703,7 @@ This version of <i>iframe-resizer</> can auto detect the most suitable ${label} 
       setTimeout(() => received({ data, sameOrigin: true }))
 
     addEventListener(window, 'message', received)
-    addEventListener(window, 'readystatechange', checkLateLoaded)
+    addEventListener(document, 'readystatechange', checkLateLoaded)
 
     setTimeout(checkLateLoaded)
   }


### PR DESCRIPTION
The listener for `readystatechange` was wrongly attached to `window` instead of `document`.