### PR TITLE
Only send `init` to iframe that sent `ready` message

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -655,9 +655,8 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
     warnOnNoResponse(iframeId, settings)
   }
 
-  function iFrameReadyMsgReceived(source) {
+  const iFrameReadyMsgReceived = (source) =>
     Object.keys(settings).forEach(initFromIframe(source))
-  }
 
   function firstRun() {
     if (!settings[iframeId]) return

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -651,12 +651,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
   const initFromIframe = (source) => (iframeId) => {
     const { ready, postMessageTarget } = settings[iframeId]
     if (ready || source !== postMessageTarget) return
-    trigger(
-      'iframe requested init',
-      createOutgoingMsg(iframeId),
-      iframeId,
-      source,
-    )
+    trigger('iframe requested init', createOutgoingMsg(iframeId), iframeId)
     warnOnNoResponse(iframeId, settings)
   }
 

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -648,14 +648,20 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
     }
   }
 
-  function initFromIframe(iframeId) {
-    if (settings[iframeId].ready) return
-    trigger('iframe requested init', createOutgoingMsg(iframeId), iframeId)
+  const initFromIframe = (source) => (iframeId) => {
+    const { ready, postMessageTarget } = settings[iframeId]
+    if (ready || source !== postMessageTarget) return
+    trigger(
+      'iframe requested init',
+      createOutgoingMsg(iframeId),
+      iframeId,
+      source,
+    )
     warnOnNoResponse(iframeId, settings)
   }
 
-  function iFrameReadyMsgReceived() {
-    Object.keys(settings).forEach(initFromIframe)
+  function iFrameReadyMsgReceived(source) {
+    Object.keys(settings).forEach(initFromIframe(source))
   }
 
   function firstRun() {
@@ -670,7 +676,7 @@ See <u>https://iframe-resizer.com/setup/#child-page-setup</> for more details.
   let iframeId = null
 
   if (msg === '[iFrameResizerChild]Ready') {
-    iFrameReadyMsgReceived()
+    iFrameReadyMsgReceived(event.source)
     return
   }
 


### PR DESCRIPTION
When the child `ready` message is received, only send response to the iframe that sent the `ready` message. This avoids trigging the timer on iframes that have not yet loaded.