### PR TITLE
If an iframe has both `src` and `srcdoc` unset. Delay initialisation until `load` event from the iframe.

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1084,7 +1084,7 @@ Use of the <b>resize()</> method from the parent page is deprecated and will be 
 
     const { src, srcdoc } = iframe
 
-    if (!srcdoc && (src === '' || src === 'about:blank')) return
+    if (!srcdoc && (src == null || src === '' || src === 'about:blank')) return
 
     createIframeLoaded(INIT)()
   }


### PR DESCRIPTION
Add conditional initialization for empty iframes by checking if they have content before triggering initialization. If an iframe has both src and srcdoc unset (empty), initialization is delayed until the iframe's onload event.