### PR TITLE
package/vue: Ensure log prop accepts the same values as the core library

### DIFF
--- a/packages/vue/iframe-resizer.vue
+++ b/packages/vue/iframe-resizer.vue
@@ -41,8 +41,22 @@
         type: String,
       },
       log: {
-        type: [String, Number],
-        validator: value => value === COLLAPSE || value === EXPAND || value === -1,
+        type: [String, Boolean, Number],
+        validator: (value) => {
+          if (typeof value === 'boolean') {
+            return true;
+          }
+          
+          if (typeof value === 'string') {
+            return [COLLAPSE, EXPAND].includes(value);
+          }
+
+          if (typeof value === 'number') {
+            return value === -1;
+          }
+
+          return false
+        },
         default: undefined,
       },
       inPageLinks: {
@@ -94,8 +108,8 @@
       const consoleGroup = createAutoConsoleGroup(consoleOptions)
       consoleGroup.event('setup')
 
-      if ([COLLAPSE, EXPAND].includes(options.log)) {
-        consoleGroup.log('Created Vue competent')
+      if ([COLLAPSE, EXPAND, true].includes(options.log)) {
+        consoleGroup.log('Created Vue component')
       }
     },
     

--- a/packages/vue/iframe-resizer.vue
+++ b/packages/vue/iframe-resizer.vue
@@ -14,6 +14,7 @@
   const createAutoConsoleGroup = esModuleInterop(acg)
   
   const EXPAND = 'expanded'
+  const COLLAPSE = 'collapsed'
 
   export default {
     name: 'IframeResizer',
@@ -40,8 +41,9 @@
         type: String,
       },
       log: {
-        type: [String, Boolean],
-        default: false,
+        type: [String, Number],
+        validator: value => value === COLLAPSE || value === EXPAND || value === -1,
+        default: undefined,
       },
       inPageLinks: {
         type: Boolean,
@@ -81,8 +83,6 @@
         onResized: (...args) => self.$emit('onResized', ...args),
       }
 
-      if (options.log === '') options.log = true
-
       const connectWithOptions = connectResizer(options)
       self.resizer = connectWithOptions(iframe)
 
@@ -93,7 +93,10 @@
 
       const consoleGroup = createAutoConsoleGroup(consoleOptions)
       consoleGroup.event('setup')
-      if (options.log) consoleGroup.log('Created Vue competent')
+
+      if ([COLLAPSE, EXPAND].includes(options.log)) {
+        consoleGroup.log('Created Vue competent')
+      }
     },
     
     beforeUnmount() {

--- a/packages/vue/iframe-resizer.vue
+++ b/packages/vue/iframe-resizer.vue
@@ -5,6 +5,7 @@
 <script>
   import connectResizer from '@iframe-resizer/core'
   import acg from 'auto-console-group'
+  import { EXPAND, COLLAPSE } from '../common/consts'
 
   const esModuleInterop = (mod) =>
     // eslint-disable-next-line no-underscore-dangle
@@ -12,9 +13,6 @@
 
   // Deal with UMD not converting default exports to named exports
   const createAutoConsoleGroup = esModuleInterop(acg)
-  
-  const EXPAND = 'expanded'
-  const COLLAPSE = 'collapsed'
 
   export default {
     name: 'IframeResizer',
@@ -43,19 +41,16 @@
       log: {
         type: [String, Boolean, Number],
         validator: (value) => {
-          if (typeof value === 'boolean') {
-            return true;
+          switch (value) {
+            case COLLAPSE:
+            case EXPAND:
+            case false:
+            case true:
+            case -1:
+              return true
+            default:
+              return false
           }
-          
-          if (typeof value === 'string') {
-            return [COLLAPSE, EXPAND].includes(value);
-          }
-
-          if (typeof value === 'number') {
-            return value === -1;
-          }
-
-          return false
         },
         default: undefined,
       },


### PR DESCRIPTION
Hi,

while using the Vue package in our web project, we noticed that the type of `log` passed to the Vue component is not consistent with the one in the core library.

We would like to disable the version info log from the core library by passing `-1` (see [line 1267](https://github.com/davidjbradshaw/iframe-resizer/blob/04add61d0a4c6c521e4c94bdce8783311de34ac1/packages/core/index.js#L1267)). However, the Vue component does not accept the value `-1` and still logs its own message to the console (see line [84](https://github.com/davidjbradshaw/iframe-resizer/blob/04add61d0a4c6c521e4c94bdce8783311de34ac1/packages/vue/iframe-resizer.vue#L84) and [96](https://github.com/davidjbradshaw/iframe-resizer/blob/04add61d0a4c6c521e4c94bdce8783311de34ac1/packages/vue/iframe-resizer.vue#L96)):

This PR adds the following changes:
1. Improves the check for the log group by explicitly checking only for the `expanded` and `collapsed` options.
2. Adds a `validator` to the `log` prop definition to align with the core library.

We’re open to feedback and discussion.