### PR TITLE
Fix: Mobile Safari navigation fails to update page

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -1096,7 +1096,7 @@ Use of the <b>resize()</> method from the parent page is deprecated and will be 
       const { firstRun, iframe } = settings[id]
 
       trigger(eventType, message, id)
-      if (!isInit(eventType) && !isLazy(iframe)) warnOnNoResponse(id, settings)
+      if (!(isInit(eventType) && isLazy(iframe))) warnOnNoResponse(id, settings)
 
       if (!firstRun) checkReset()
     }


### PR DESCRIPTION
Using `beforeUnload` breaks resizing of new pages in Mobile Safari and backwards compatibility