### PR TITLE
Add `checkOrigin` to connection timeout warning

### DIFF
--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -1,13 +1,10 @@
 import { OBJECT } from '../common/consts'
 import { advise, event } from './console'
 
-const getOrigin = (url) => {
-  const target = new URL(url)
-  return target.origin
-}
+const getOrigin = (url) => new URL(url).origin
 
 function showWarning(id, settings) {
-  const { checkOrigin, iframe, loadedFirstPage, waitForLoad } = settings[id]
+  const { checkOrigin, iframe, initialisedFirstPage, waitForLoad } = settings[id]
   const { src, sandbox } = iframe
   const targetOrigin = getOrigin(src)
   const hasSandbox =
@@ -30,7 +27,7 @@ The <b>checkOrigin</> option is currently enabled. If the iframe redirects away 
 `
     : ''
 }${
-      waitForLoad && !loadedFirstPage
+      waitForLoad && !initialisedFirstPage
         ? `
 The <b>waitForLoad</> option is currently set to <b>'true'</>. If the iframe loads before <i>iframe-resizer</> runs, this option will prevent <i>iframe-resizer</> initialising. To disable this option, set <b>waitForLoad</> to <b>'false'</>.  
 `
@@ -56,7 +53,7 @@ export default function warnOnNoResponse(id, settings) {
     settings[id].msgTimeout = undefined
 
     if (initialised) {
-      settings[id].loadedFirstPage = true
+      settings[id].initialisedFirstPage = true
       return
     }
 

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -9,17 +9,19 @@ const getOrigin = (url) => {
   }
 }
 
+const allowsScriptsAndOrigin = (sandbox) =>
+  typeof sandbox === OBJECT &&
+  sandbox.length > 0 &&
+  !(sandbox.contains('allow-scripts') && sandbox.contains('allow-same-origin'))
+
 function showWarning(id, settings) {
-  const { checkOrigin, iframe, initialisedFirstPage, waitForLoad } =
-    settings[id]
-  const { src, sandbox } = iframe
+  const {
+    checkOrigin,
+    iframe: { src, sandbox },
+    initialisedFirstPage,
+    waitForLoad,
+  } = settings[id]
   const targetOrigin = getOrigin(src)
-  const hasSandbox =
-    typeof sandbox === OBJECT &&
-    sandbox.length > 0 &&
-    !(
-      sandbox.contains('allow-scripts') && sandbox.contains('allow-same-origin')
-    )
 
   event(id, 'noResponse')
   advise(
@@ -40,7 +42,7 @@ The <b>waitForLoad</> option is currently set to <b>'true'</>. If the iframe loa
 `
         : ''
     }${
-      hasSandbox
+      allowsScriptsAndOrigin(sandbox)
         ? `
 The iframe has the <b>sandbox</> attribute, please ensure it contains both the <i>'allow-same-origin'</> and <i>'allow-scripts'</> values.
 `

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -1,10 +1,17 @@
 import { OBJECT } from '../common/consts'
 import { advise, event } from './console'
 
-const getOrigin = (url) => new URL(url).origin
+const getOrigin = (url) => {
+  try {
+    return new URL(url).origin
+  } catch (error) {
+    return null
+  }
+}
 
 function showWarning(id, settings) {
-  const { checkOrigin, iframe, initialisedFirstPage, waitForLoad } = settings[id]
+  const { checkOrigin, iframe, initialisedFirstPage, waitForLoad } =
+    settings[id]
   const { src, sandbox } = iframe
   const targetOrigin = getOrigin(src)
   const hasSandbox =

--- a/packages/core/timeout.js
+++ b/packages/core/timeout.js
@@ -30,13 +30,13 @@ The iframe (<i>${id}</>) has not responded within ${settings[id].warningTimeout 
 ${
   checkOrigin && targetOrigin
     ? `
-The <b>checkOrigin</> option is currently enabled. If the iframe redirects away from <i>${targetOrigin}</>, then the connection to the iframe may be blocked by the browser. To disable this option, set <b>checkOrigin</> to <b>'false'</> or an array of allowed origins. See <u>https://iframe-resizer.com/checkorigin</> for more information.  
+The <b>checkOrigin</> option is currently enabled. If the iframe redirects away from <i>${targetOrigin}</>, then the connection to the iframe may be blocked by the browser. To disable this option, set <b>checkOrigin</> to <b>'false'</> or an array of allowed origins. See <u>https://iframe-resizer.com/checkorigin</> for more information.
 `
     : ''
 }${
       waitForLoad && !initialisedFirstPage
         ? `
-The <b>waitForLoad</> option is currently set to <b>'true'</>. If the iframe loads before <i>iframe-resizer</> runs, this option will prevent <i>iframe-resizer</> initialising. To disable this option, set <b>waitForLoad</> to <b>'false'</>.  
+The <b>waitForLoad</> option is currently set to <b>'true'</>. If the iframe loads before <i>iframe-resizer</> runs, this option will prevent <i>iframe-resizer</> initialising. To disable this option, set <b>waitForLoad</> to <b>'false'</>.
 `
         : ''
     }${

--- a/packages/core/timeout.test.js
+++ b/packages/core/timeout.test.js
@@ -55,16 +55,25 @@ describe('warnOnNoResponse', () => {
 
     warnOnNoResponse(id, settings)
 
-    expect(setTimeout).toHaveBeenCalled()
+    expect(setTimeout).toHaveBeenCalledWith(
+      expect.any(Function),
+      settings[id].warningTimeout,
+    )
 
     jest.advanceTimersByTime(settings[id].warningTimeout + 1)
 
     expect(event).toHaveBeenCalledWith(id, 'noResponse')
     expect(advise).toHaveBeenCalledTimes(1)
-    const [, message] = advise.mock.calls[0]
+    expect(advise).toHaveBeenCalledWith(
+      id,
+      expect.stringMatching(/No response from iframe/),
+    )
 
-    expect(message).toMatch(/No response from iframe/)
-    expect(message).toContain('https://foo.example:8443')
+    expect(advise).toHaveBeenCalledWith(
+      id,
+      expect.stringContaining('https://foo.example:8443'),
+    )
+
     expect(settings[id].loadErrorShown).toBe(true)
   })
 
@@ -75,9 +84,10 @@ describe('warnOnNoResponse', () => {
     warnOnNoResponse(id, settings)
     jest.advanceTimersByTime(settings[id].warningTimeout + 1)
 
-    const [, message] = advise.mock.calls[0]
-
-    expect(message).not.toMatch(/checkOrigin/)
+    expect(advise).toHaveBeenCalledWith(
+      id,
+      expect.not.stringMatching(/checkOrigin/),
+    )
   })
 
   it('adds sandbox advice when sandbox is present but missing required tokens', () => {
@@ -94,11 +104,16 @@ describe('warnOnNoResponse', () => {
     warnOnNoResponse(id, settings)
     jest.advanceTimersByTime(settings[id].warningTimeout + 1)
 
-    const [, message] = advise.mock.calls[0]
+    expect(advise).toHaveBeenCalledWith(id, expect.stringMatching(/sandbox/))
+    expect(advise).toHaveBeenCalledWith(
+      id,
+      expect.stringMatching(/allow-same-origin/),
+    )
 
-    expect(message).toMatch(/sandbox/)
-    expect(message).toMatch(/allow-same-origin/)
-    expect(message).toMatch(/allow-scripts/)
+    expect(advise).toHaveBeenCalledWith(
+      id,
+      expect.stringMatching(/allow-scripts/),
+    )
   })
 
   it('includes waitForLoad advice when enabled and first page not initialised', () => {
@@ -112,9 +127,10 @@ describe('warnOnNoResponse', () => {
     warnOnNoResponse(id, settings)
     jest.advanceTimersByTime(settings[id].warningTimeout + 1)
 
-    const [, message] = advise.mock.calls[0]
-
-    expect(message).toMatch(/waitForLoad/)
+    expect(advise).toHaveBeenCalledWith(
+      id,
+      expect.stringMatching(/waitForLoad/),
+    )
   })
 
   it('when already initialised: sets initialisedFirstPage and does not warn', () => {
@@ -177,8 +193,9 @@ describe('warnOnNoResponse', () => {
     warnOnNoResponse(id, settings)
     jest.advanceTimersByTime(settings[id].warningTimeout + 1)
 
-    const [, message] = advise.mock.calls[0]
-
-    expect(message).not.toMatch(/checkOrigin/)
+    expect(advise).toHaveBeenCalledWith(
+      id,
+      expect.not.stringMatching(/checkOrigin/),
+    )
   })
 })


### PR DESCRIPTION
Add `checkOrigin` to connection timeout warning if it is enabled.

Also only show `waitForLoad` warning if it is the first page loaded into the iframe.