### PR TITLE
Fix: Use last IntersectionObserver entry for visibility state

### DIFF
--- a/packages/child/observers/visibility.js
+++ b/packages/child/observers/visibility.js
@@ -4,7 +4,7 @@ import { info } from '../console'
 
 export default function visibilityObserver(callback) {
   const observer = new IntersectionObserver(
-    (entries) => callback(entries[0].isIntersecting),
+    (entries) => callback(entries.at(-1).isIntersecting),
     {
       threshold: 0,
     },


### PR DESCRIPTION
In #1554, regarding

> However, if you want to try your suggested fix, I would be happy to take a PR for this.

.. in this comment: https://github.com/davidjbradshaw/iframe-resizer/issues/1554#issuecomment-3781104945