### PR TITLE
Fix resize failure after forced content scrolling

### DIFF
--- a/packages/child/size/content.test.ts
+++ b/packages/child/size/content.test.ts
@@ -12,7 +12,7 @@ import {
   VISIBILITY_OBSERVER,
 } from '../../common/consts'
 import state from '../values/state'
-import getContentSize from './content'
+import getContentSize, { ensureContentPosition } from './content'
 
 vi.mock('../console', () => ({
   info: vi.fn(),
@@ -28,6 +28,53 @@ vi.mock('./get-new', () => ({
 vi.mock('./change-detected', () => ({
   default: vi.fn(),
 }))
+
+describe('ensureContentPosition', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('resets scroll and logs when scrolled', async () => {
+    const { info } = await import('../console')
+    const scrollTo = vi.fn()
+    vi.stubGlobal('scrollY', 100)
+    vi.stubGlobal('scrollX', 0)
+    vi.stubGlobal('scrollTo', scrollTo)
+
+    ensureContentPosition()
+
+    expect(scrollTo).toHaveBeenCalledWith(0, 0)
+    expect(info).toHaveBeenCalledWith('Reset iframe scroll position to (0, 0)')
+
+    vi.unstubAllGlobals()
+  })
+
+  test('resets when scrollX is non-zero', () => {
+    const scrollTo = vi.fn()
+    vi.stubGlobal('scrollY', 0)
+    vi.stubGlobal('scrollX', 50)
+    vi.stubGlobal('scrollTo', scrollTo)
+
+    ensureContentPosition()
+
+    expect(scrollTo).toHaveBeenCalledWith(0, 0)
+
+    vi.unstubAllGlobals()
+  })
+
+  test('does nothing when already at origin', () => {
+    const scrollTo = vi.fn()
+    vi.stubGlobal('scrollY', 0)
+    vi.stubGlobal('scrollX', 0)
+    vi.stubGlobal('scrollTo', scrollTo)
+
+    ensureContentPosition()
+
+    expect(scrollTo).not.toHaveBeenCalled()
+
+    vi.unstubAllGlobals()
+  })
+})
 
 describe('child/size/content', () => {
   beforeEach(() => {

--- a/packages/child/size/content.test.ts
+++ b/packages/child/size/content.test.ts
@@ -34,6 +34,10 @@ describe('ensureContentPosition', () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   test('resets scroll and logs when scrolled', async () => {
     const { info } = await import('../console')
     const scrollTo = vi.fn()
@@ -45,8 +49,6 @@ describe('ensureContentPosition', () => {
 
     expect(scrollTo).toHaveBeenCalledWith(0, 0)
     expect(info).toHaveBeenCalledWith('Reset iframe scroll position to (0, 0)')
-
-    vi.unstubAllGlobals()
   })
 
   test('resets when scrollX is non-zero', () => {
@@ -58,8 +60,6 @@ describe('ensureContentPosition', () => {
     ensureContentPosition()
 
     expect(scrollTo).toHaveBeenCalledWith(0, 0)
-
-    vi.unstubAllGlobals()
   })
 
   test('does nothing when already at origin', () => {

--- a/packages/child/size/content.ts
+++ b/packages/child/size/content.ts
@@ -19,6 +19,13 @@ import state from '../values/state'
 import isSizeChangeDetected from './change-detected'
 import { getNewHeight, getNewWidth } from './get-new'
 
+export function ensureContentPosition(): void {
+  if (window.scrollY !== 0 || window.scrollX !== 0) {
+    info('Reset iframe scroll position to (0, 0)')
+    window.scrollTo(0, 0)
+  }
+}
+
 export default function getContentSize(
   triggerEvent: string,
   triggerEventDesc: string,
@@ -26,6 +33,8 @@ export default function getContentSize(
   customWidth?: number,
 ): { height: number; width: number } | null {
   const { heightCalcMode, widthCalcMode } = settings
+
+  ensureContentPosition()
 
   const newHeight = customHeight ?? getNewHeight(heightCalcMode, triggerEvent)
   const newWidth = customWidth ?? getNewWidth(widthCalcMode, triggerEvent)


### PR DESCRIPTION
Pasting a lot of content into an auto sizing `<textarea>` can cause the page in the iframe to scroll. 

This PR detects and fixes this when it happens.