### PR TITLE
Fix TypeScript resolution of @iframe-resizer/vue exports

### DIFF
--- a/vite.config/shared/pkgJson.js
+++ b/vite.config/shared/pkgJson.js
@@ -53,10 +53,15 @@ const customConfig = (file) => {
         types,
         exports: {
           '.': {
+            types: `./${types}`,
             import: `./${module}`,
             require: './index.umd.js',
           },
-          './sfc': './iframe-resizer.vue',
+          './sfc': {
+            types: './iframe-resizer.vue.d.ts',
+            default: './iframe-resizer.vue',
+          },
+          './package.json': './package.json',
         },
         peerDependencies: {
           vue: '^3.3.0',


### PR DESCRIPTION
Refs #1692

## Background

[#1692](https://github.com/davidjbradshaw/iframe-resizer/issues/1692) reports that `import IframeResizer from '@iframe-resizer/vue/sfc'` fails to resolve in Nuxt. On v5 that is a real runtime bug — the published `package.json` declares the subpath in the **`browser`** field, which cannot create entry points:

```json
"browser": { "./sfc": "iframe-resizer.vue" }
```

That part is already fixed on v6, which generates a proper `exports` map. Verified against `6.0.0-beta.11` in a bare Vite + `@vitejs/plugin-vue` project:

```
Rolldown failed to resolve import "@iframe-resizer/vue/sfc"   ← 5.5.9
✓ built in 85ms                                               ← 6.0.0-beta.11
```

## What this PR fixes

The v6 `exports` map has no `types` conditions. Under `moduleResolution: "bundler"` / `"node16"` — the Nuxt default — TypeScript ignores the top-level `types` field once `exports` is present, so **both** entry points fail to type-resolve (which is why the reporter needed `// @ts-ignore`):

```
src/check.ts(1,27): error TS2307: Cannot find module '@iframe-resizer/vue/sfc' or its corresponding type declarations.
src/check.ts(2,20): error TS7016: Could not find a declaration file for module '@iframe-resizer/vue'.
  There are types at '.../index.d.ts', but this result could not be resolved when respecting package.json "exports".
  The '@iframe-resizer/vue' library may need to update its package.json or typings.
```

A side effect is that the rich `iframe-resizer.vue.d.ts` produced by `build-scripts/generate-sfc-dts.js` was shipping in the tarball completely unreferenced.

## Change

`vite.config/shared/pkgJson.js`, `vue` case:

```json
"exports": {
  ".": {
    "types": "./index.d.ts",
    "import": "./index.esm.js",
    "require": "./index.umd.js"
  },
  "./sfc": {
    "types": "./iframe-resizer.vue.d.ts",
    "default": "./iframe-resizer.vue"
  },
  "./package.json": "./package.json"
}
```

## Verification

Built `dist/vue`, packed it, and installed the tarball into a Vite 8 + Vue 3 consumer:

- `tsc --moduleResolution bundler` — clean for `@iframe-resizer/vue`, `@iframe-resizer/vue/sfc`, and type-only imports (`IframeResizerProps`, `IFrameOptions`) from both
- Negative test confirms types are real, not `any`: an unknown prop still errors with `TS2353`
- `vite build` succeeds, 13 modules transformed
- `npm run eslint:fix` clean, unit tests 848/848 passing

## Follow-ups (not in this PR)

- The same missing-`types`-condition gap exists in the `common` case (`.` and `./consts`) and in `astro`'s `.` export.
- v5 still needs the `browser` → `exports` fix backported, since `5.5.9` is `latest` and is what the reporter hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)